### PR TITLE
test: testes automatizados no backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "node --watch --no-warnings=ExperimentalWarning src/index.js",
-    "start": "node --no-warnings=ExperimentalWarning src/index.js"
+    "start": "node --no-warnings=ExperimentalWarning src/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,5 +16,9 @@
     "express": "^4.18.3",
     "jspdf": "^2.5.1",
     "jspdf-autotable": "^3.8.2"
+  },
+  "devDependencies": {
+    "supertest": "^7.2.2",
+    "vitest": "^4.0.18"
   }
 }

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,26 @@
+import express from 'express';
+import cors from 'cors';
+import employeesRouter from './routes/employees.js';
+import shiftTypesRouter from './routes/shiftTypes.js';
+import schedulesRouter from './routes/schedules.js';
+import exportRouter from './routes/export.js';
+import { errorHandler, notFound } from './middleware/errorHandler.js';
+
+const app = express();
+
+app.use(cors({ origin: 'http://localhost:5173', credentials: true }));
+app.use(express.json());
+
+app.use('/api/employees', employeesRouter);
+app.use('/api/shift-types', shiftTypesRouter);
+app.use('/api/schedules', schedulesRouter);
+app.use('/api/export', exportRouter);
+
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+app.use(notFound);
+app.use(errorHandler);
+
+export default app;

--- a/backend/src/db/database.js
+++ b/backend/src/db/database.js
@@ -5,13 +5,19 @@ import { dirname, join } from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const DB_PATH = join(__dirname, '..', '..', 'escala.db');
+const DB_PATH = process.env.DB_PATH || join(__dirname, '..', '..', 'escala.db');
 
 let db;
 
+/** Resets the singleton — use only in tests to get a fresh DB. */
+export function resetDb() {
+  if (db) { try { db.close(); } catch {} }
+  db = undefined;
+}
+
 export function getDb() {
   if (!db) {
-    db = new DatabaseSync(DB_PATH);
+    db = new DatabaseSync(process.env.DB_PATH || DB_PATH);
     db.exec('PRAGMA journal_mode = WAL');
     db.exec('PRAGMA foreign_keys = ON');
     initSchema();

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,36 +1,9 @@
-import express from 'express';
-import cors from 'cors';
 import { getDb } from './db/database.js';
-import employeesRouter from './routes/employees.js';
-import shiftTypesRouter from './routes/shiftTypes.js';
-import schedulesRouter from './routes/schedules.js';
-import exportRouter from './routes/export.js';
-import { errorHandler, notFound } from './middleware/errorHandler.js';
+import app from './app.js';
 
 const PORT = process.env.PORT || 3001;
-const app = express();
 
-// Middlewares
-app.use(cors({ origin: 'http://localhost:5173', credentials: true }));
-app.use(express.json());
-
-// Initialize DB on startup
-getDb();
-
-// Routes
-app.use('/api/employees', employeesRouter);
-app.use('/api/shift-types', shiftTypesRouter);
-app.use('/api/schedules', schedulesRouter);
-app.use('/api/export', exportRouter);
-
-// Health check
-app.get('/api/health', (req, res) => {
-  res.json({ status: 'ok', timestamp: new Date().toISOString() });
-});
-
-// 404 + Error handling
-app.use(notFound);
-app.use(errorHandler);
+getDb(); // Initialize DB on startup
 
 app.listen(PORT, () => {
   console.log(`✅ Escala Trabalho API running at http://localhost:${PORT}`);

--- a/backend/src/tests/employees.test.js
+++ b/backend/src/tests/employees.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../app.js';
+import { freshDb, createEmployee } from './helpers.js';
+
+beforeEach(() => freshDb());
+
+describe('GET /api/employees', () => {
+  it('retorna array vazio quando não há funcionários', async () => {
+    const res = await request(app).get('/api/employees');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('retorna apenas funcionários ativos por padrão', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Ana' });
+    db.prepare("UPDATE employees SET active = 0 WHERE id = ?").run(emp.id);
+    createEmployee(db, { name: 'Bruno' });
+
+    const res = await request(app).get('/api/employees');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].name).toBe('Bruno');
+  });
+
+  it('retorna todos com includeInactive=true', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Ana' });
+    db.prepare("UPDATE employees SET active = 0 WHERE id = ?").run(emp.id);
+    createEmployee(db, { name: 'Bruno' });
+
+    const res = await request(app).get('/api/employees?includeInactive=true');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+  });
+
+  it('inclui restRules em cada funcionário', async () => {
+    const db = freshDb();
+    createEmployee(db, { name: 'Ana' });
+
+    const res = await request(app).get('/api/employees');
+    expect(res.status).toBe(200);
+    expect(res.body[0].restRules).toBeTruthy();
+    expect(res.body[0].restRules.min_rest_hours).toBe(11);
+  });
+});
+
+describe('GET /api/employees/:id', () => {
+  it('retorna 404 para id inexistente', async () => {
+    const res = await request(app).get('/api/employees/9999');
+    expect(res.status).toBe(404);
+  });
+
+  it('retorna o funcionário pelo id', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Carlos' });
+
+    const res = await request(app).get(`/api/employees/${emp.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Carlos');
+    expect(res.body.restRules).toBeTruthy();
+  });
+});
+
+describe('POST /api/employees', () => {
+  it('cria funcionário com campos obrigatórios', async () => {
+    freshDb();
+    const res = await request(app)
+      .post('/api/employees')
+      .send({ name: 'Diana', cargo: 'Médica', setor: 'UTI' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Diana');
+    expect(res.body.cargo).toBe('Médica');
+    expect(res.body.active).toBe(1);
+    expect(res.body.restRules).toBeTruthy();
+  });
+
+  it('retorna 400 quando faltam campos obrigatórios', async () => {
+    freshDb();
+    const res = await request(app).post('/api/employees').send({ name: 'Sem cargo' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeTruthy();
+  });
+
+  it('aplica regras de descanso customizadas', async () => {
+    freshDb();
+    const res = await request(app)
+      .post('/api/employees')
+      .send({ name: 'Eduardo', cargo: 'Enfermeiro', setor: 'PS', restRules: { min_rest_hours: 12, days_off_per_week: 2 } });
+
+    expect(res.status).toBe(201);
+    expect(res.body.restRules.min_rest_hours).toBe(12);
+    expect(res.body.restRules.days_off_per_week).toBe(2);
+  });
+});
+
+describe('PUT /api/employees/:id', () => {
+  it('atualiza nome do funcionário', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Fernanda' });
+
+    const res = await request(app)
+      .put(`/api/employees/${emp.id}`)
+      .send({ name: 'Fernanda Silva' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Fernanda Silva');
+  });
+
+  it('retorna 404 para id inexistente', async () => {
+    freshDb();
+    const res = await request(app).put('/api/employees/9999').send({ name: 'X' });
+    expect(res.status).toBe(404);
+  });
+
+  it('desativa funcionário via active=false', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Gustavo' });
+
+    const res = await request(app).put(`/api/employees/${emp.id}`).send({ active: false });
+    expect(res.status).toBe(200);
+    expect(res.body.active).toBe(0);
+  });
+});
+
+describe('DELETE /api/employees/:id', () => {
+  it('faz soft delete (active=0)', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Helena' });
+
+    const res = await request(app).delete(`/api/employees/${emp.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const check = db.prepare('SELECT active FROM employees WHERE id = ?').get(emp.id);
+    expect(check.active).toBe(0);
+  });
+
+  it('retorna 404 para id inexistente', async () => {
+    freshDb();
+    const res = await request(app).delete('/api/employees/9999');
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/src/tests/helpers.js
+++ b/backend/src/tests/helpers.js
@@ -1,0 +1,22 @@
+import { resetDb, getDb } from '../db/database.js';
+
+/** Reseta o banco e retorna uma instância limpa com seed aplicado. */
+export function freshDb() {
+  resetDb();
+  return getDb(); // recria :memory: com schema + seed dos shift_types
+}
+
+/** Cria um funcionário via banco direto e retorna o objeto completo. */
+export function createEmployee(db, { name = 'Teste', cargo = 'Técnico', setor = 'TI' } = {}) {
+  const res = db.prepare('INSERT INTO employees (name, cargo, setor) VALUES (?, ?, ?)').run(name, cargo, setor);
+  const emp = db.prepare('SELECT * FROM employees WHERE id = ?').get(res.lastInsertRowid);
+  db.prepare(
+    'INSERT INTO employee_rest_rules (employee_id, min_rest_hours, days_off_per_week) VALUES (?, 11, 1)'
+  ).run(emp.id);
+  return emp;
+}
+
+/** Retorna o id do shift_type pelo nome. */
+export function shiftId(db, name) {
+  return db.prepare('SELECT id FROM shift_types WHERE name = ?').get(name)?.id;
+}

--- a/backend/src/tests/schedules.test.js
+++ b/backend/src/tests/schedules.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../app.js';
+import { freshDb, createEmployee, shiftId } from './helpers.js';
+
+beforeEach(() => freshDb());
+
+describe('GET /api/schedules', () => {
+  it('retorna 400 sem month e year', async () => {
+    const res = await request(app).get('/api/schedules');
+    expect(res.status).toBe(400);
+  });
+
+  it('retorna estrutura correta sem entradas', async () => {
+    const res = await request(app).get('/api/schedules?month=1&year=2025');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('month', 1);
+    expect(res.body).toHaveProperty('year', 2025);
+    expect(res.body.entries).toEqual([]);
+    expect(res.body.totals).toEqual([]);
+  });
+});
+
+describe('POST /api/schedules/generate', () => {
+  it('retorna 400 sem month e year', async () => {
+    const res = await request(app).post('/api/schedules/generate').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('gera escala com sucesso quando há funcionários', async () => {
+    const db = freshDb();
+    createEmployee(db, { name: 'João', cargo: 'Técnico', setor: 'TI' });
+    createEmployee(db, { name: 'Maria', cargo: 'Técnica', setor: 'TI' });
+
+    const res = await request(app)
+      .post('/api/schedules/generate')
+      .send({ month: 1, year: 2025 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('gera escala vazia quando não há funcionários', async () => {
+    freshDb();
+    const res = await request(app)
+      .post('/api/schedules/generate')
+      .send({ month: 1, year: 2025 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const schedule = await request(app).get('/api/schedules?month=1&year=2025');
+    expect(schedule.body.entries).toHaveLength(0);
+  });
+
+  it('não sobrescreve entradas bloqueadas por padrão', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Ana' });
+    const sid = shiftId(db, 'Manhã');
+
+    // Insere entrada bloqueada manualmente
+    db.prepare(
+      'INSERT INTO schedule_entries (employee_id, shift_type_id, date, is_day_off, is_locked) VALUES (?, ?, ?, 0, 1)'
+    ).run(emp.id, sid, '2025-01-15');
+
+    await request(app).post('/api/schedules/generate').send({ month: 1, year: 2025 });
+
+    const entry = db
+      .prepare('SELECT * FROM schedule_entries WHERE employee_id = ? AND date = ?')
+      .get(emp.id, '2025-01-15');
+
+    expect(entry.shift_type_id).toBe(sid);
+    expect(entry.is_locked).toBe(1);
+  });
+});
+
+describe('PUT /api/schedules/entry/:id', () => {
+  it('retorna 404 para id inexistente', async () => {
+    freshDb();
+    const res = await request(app).put('/api/schedules/entry/9999').send({ is_day_off: true });
+    expect(res.status).toBe(404);
+  });
+
+  it('atualiza is_day_off de uma entrada', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Carlos' });
+    const sid = shiftId(db, 'Tarde');
+
+    const result = db
+      .prepare('INSERT INTO schedule_entries (employee_id, shift_type_id, date, is_day_off) VALUES (?, ?, ?, 0)')
+      .run(emp.id, sid, '2025-03-10');
+
+    const res = await request(app)
+      .put(`/api/schedules/entry/${result.lastInsertRowid}`)
+      .send({ is_day_off: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.is_day_off).toBe(1);
+  });
+
+  it('atualiza notas de uma entrada', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Diana' });
+
+    const result = db
+      .prepare('INSERT INTO schedule_entries (employee_id, date, is_day_off) VALUES (?, ?, 1)')
+      .run(emp.id, '2025-03-12');
+
+    const res = await request(app)
+      .put(`/api/schedules/entry/${result.lastInsertRowid}`)
+      .send({ notes: 'Licença médica' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.notes).toBe('Licença médica');
+  });
+});
+
+describe('DELETE /api/schedules/month', () => {
+  it('retorna 400 sem month e year', async () => {
+    const res = await request(app).delete('/api/schedules/month');
+    expect(res.status).toBe(400);
+  });
+
+  it('remove todas as entradas do mês', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Eduardo' });
+    const sid = shiftId(db, 'Noturno');
+
+    db.prepare('INSERT INTO schedule_entries (employee_id, shift_type_id, date, is_day_off) VALUES (?, ?, ?, 0)')
+      .run(emp.id, sid, '2025-05-01');
+    db.prepare('INSERT INTO schedule_entries (employee_id, shift_type_id, date, is_day_off) VALUES (?, ?, ?, 0)')
+      .run(emp.id, sid, '2025-05-02');
+
+    const res = await request(app).delete('/api/schedules/month?month=5&year=2025');
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(2);
+
+    const schedule = await request(app).get('/api/schedules?month=5&year=2025');
+    expect(schedule.body.entries).toHaveLength(0);
+  });
+
+  it('não remove entradas de outros meses', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Flávia' });
+    const sid = shiftId(db, 'Manhã');
+
+    db.prepare('INSERT INTO schedule_entries (employee_id, shift_type_id, date, is_day_off) VALUES (?, ?, ?, 0)')
+      .run(emp.id, sid, '2025-04-15');
+
+    await request(app).delete('/api/schedules/month?month=5&year=2025');
+
+    const other = await request(app).get('/api/schedules?month=4&year=2025');
+    expect(other.body.entries).toHaveLength(1);
+  });
+});
+
+describe('GET /api/health', () => {
+  it('retorna status ok', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.timestamp).toBeTruthy();
+  });
+});

--- a/backend/src/tests/shiftTypes.test.js
+++ b/backend/src/tests/shiftTypes.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../app.js';
+import { freshDb } from './helpers.js';
+
+beforeEach(() => freshDb());
+
+describe('GET /api/shift-types', () => {
+  it('retorna os 3 turnos padrão após seed', async () => {
+    const res = await request(app).get('/api/shift-types');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(3);
+    const names = res.body.map((s) => s.name);
+    expect(names).toContain('Manhã');
+    expect(names).toContain('Tarde');
+    expect(names).toContain('Noturno');
+  });
+
+  it('cada turno tem os campos necessários', async () => {
+    const res = await request(app).get('/api/shift-types');
+    const turno = res.body[0];
+    expect(turno).toHaveProperty('id');
+    expect(turno).toHaveProperty('name');
+    expect(turno).toHaveProperty('start_time');
+    expect(turno).toHaveProperty('end_time');
+    expect(turno).toHaveProperty('duration_hours');
+    expect(turno).toHaveProperty('color');
+  });
+});
+
+describe('POST /api/shift-types', () => {
+  it('cria novo turno com todos os campos', async () => {
+    const res = await request(app).post('/api/shift-types').send({
+      name: 'Intermediário',
+      start_time: '08:00',
+      end_time: '14:00',
+      duration_hours: 6,
+      color: '#34D399',
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Intermediário');
+    expect(res.body.id).toBeTruthy();
+  });
+
+  it('retorna 400 quando faltam campos', async () => {
+    const res = await request(app).post('/api/shift-types').send({ name: 'Incompleto' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeTruthy();
+  });
+
+  it('retorna 409 para nome duplicado', async () => {
+    const res = await request(app).post('/api/shift-types').send({
+      name: 'Manhã',
+      start_time: '06:00',
+      end_time: '12:00',
+      duration_hours: 6,
+      color: '#FCD34D',
+    });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/já existe/i);
+  });
+});
+
+describe('PUT /api/shift-types/:id', () => {
+  it('atualiza a cor de um turno', async () => {
+    const list = await request(app).get('/api/shift-types');
+    const turno = list.body[0];
+
+    const res = await request(app)
+      .put(`/api/shift-types/${turno.id}`)
+      .send({ color: '#FF0000' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.color).toBe('#FF0000');
+  });
+
+  it('retorna 404 para id inexistente', async () => {
+    const res = await request(app).put('/api/shift-types/9999').send({ color: '#000' });
+    expect(res.status).toBe(404);
+  });
+
+  it('retorna 409 ao renomear para nome já existente', async () => {
+    const list = await request(app).get('/api/shift-types');
+    const turno = list.body[0];
+
+    const res = await request(app)
+      .put(`/api/shift-types/${turno.id}`)
+      .send({ name: 'Tarde' });
+
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('DELETE /api/shift-types/:id', () => {
+  it('exclui turno não utilizado', async () => {
+    const created = await request(app).post('/api/shift-types').send({
+      name: 'Temporário',
+      start_time: '10:00',
+      end_time: '16:00',
+      duration_hours: 6,
+      color: '#000000',
+    });
+    expect(created.status).toBe(201);
+
+    const res = await request(app).delete(`/api/shift-types/${created.body.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const list = await request(app).get('/api/shift-types');
+    expect(list.body.find((s) => s.id === created.body.id)).toBeUndefined();
+  });
+
+  it('retorna 404 para id inexistente', async () => {
+    const res = await request(app).delete('/api/shift-types/9999');
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    env: { DB_PATH: ':memory:' },
+    sequence: { concurrent: false },
+  },
+});


### PR DESCRIPTION
## Resumo

Fecha #1 — implementa suite de testes automatizados para o backend.

- 37 testes passando (Vitest + Supertest)
- Isola banco usando SQLite `:memory:` via env var `DB_PATH`
- Separa `app.js` de `index.js` para permitir testes sem iniciar o servidor
- Cobre employees, shift-types e schedules: happy path + sad path

## Arquivos alterados

| Arquivo | Mudança |
|---|---|
| `backend/src/app.js` | Novo — exporta a app Express sem `listen()` |
| `backend/src/index.js` | Refatorado — importa `app.js` e chama `listen()` |
| `backend/src/db/database.js` | Adiciona `DB_PATH` env var + `resetDb()` para testes |
| `backend/vitest.config.js` | Novo — configura Vitest com `env: { DB_PATH: ':memory:' }` |
| `backend/package.json` | Adiciona scripts `test` e `test:watch`, deps vitest + supertest |
| `backend/src/tests/` | 3 arquivos de teste + helpers |

## Resultado dos testes

```
✓ shiftTypes.test.js (10 tests)
✓ employees.test.js (14 tests)
✓ schedules.test.js (13 tests)
Test Files: 3 passed | Tests: 37 passed
```

---
_Desenvolvedor Pleno_