### PR TITLE
fix: corrige 4 falhas de teste pos-merge do PR #8

### DIFF
--- a/backend/src/routes/schedules.js
+++ b/backend/src/routes/schedules.js
@@ -54,7 +54,7 @@ router.get('/', (req, res) => {
 });
 
 // POST /api/schedules/generate
-router.post('/generate', (req, res) => {
+router.post('/generate', async (req, res) => {
   const { month, year, overwriteLocked = false } = req.body;
 
   if (!month || !year) {
@@ -72,7 +72,7 @@ router.post('/generate', (req, res) => {
   }
 
   try {
-    const result = generateSchedule({
+    const result = await generateSchedule({
       month: m,
       year: y,
       overwriteLocked,

--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -105,6 +105,7 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
   let lastShiftName = null;
   let consecutiveHours = 0;
   const entries = [];
+  const weeklyOffDates = new Set(); // dias de folga planejados (mínimo semanal)
 
   // Count locked hours
   for (const entry of lockedEntries) {
@@ -163,6 +164,7 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
       }
 
       for (const date of selectedOff) {
+        weeklyOffDates.add(date);
         entries.push({ employee_id: employee.id, shift_type_id: null, date, is_day_off: 1, is_locked: 0 });
         consecutiveHours = 0;
         lastShiftName = null;
@@ -216,6 +218,7 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
       }
 
       for (const date of selectedOff) {
+        weeklyOffDates.add(date);
         entries.push({ employee_id: employee.id, shift_type_id: null, date, is_day_off: 1, is_locked: 0 });
         consecutiveHours = 0;
         lastShiftName = null;
@@ -223,8 +226,9 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
     }
   }
 
-  // Correction step — passa preferredShift para garantir turno correto por setor
-  const corrected = correctHours(entries, shiftTypes, shiftMap, totalHours, TARGET_HOURS, preferredShift);
+  // Correction step — passa preferredShift e weeklyOffDates para garantir turno correto por setor
+  // e preservar folgas semanais obrigatórias (regra 6)
+  const corrected = correctHours(entries, shiftTypes, shiftMap, totalHours, TARGET_HOURS, preferredShift, weeklyOffDates);
 
   // Persist
   const insertEntry = db.prepare(
@@ -380,7 +384,7 @@ function computeShiftEnd(date, shift) {
   return new Date(start.getTime() + shift.duration_hours * 60 * 60 * 1000);
 }
 
-export function correctHours(entries, shiftTypes, shiftMap, currentHours, target, preferredShift = null) {
+export function correctHours(entries, shiftTypes, shiftMap, currentHours, target, preferredShift = null, lockedOffDates = new Set()) {
   const diff = currentHours - target;
   if (Math.abs(diff) <= 6) return entries;
 
@@ -402,6 +406,7 @@ export function correctHours(entries, shiftTypes, shiftMap, currentHours, target
   } else if (diff < -6) {
     // Too few hours: convert off days to the sector's preferred shift
     // (preferredShift garante que ADM recebe turno de 10h, não 12h)
+    // Preserva folgas semanais obrigatórias (lockedOffDates) — regra 6
     const shiftToAdd =
       preferredShift ||
       shiftTypes.find((s) => s.duration_hours === DEFAULT_SHIFT_HOURS) ||
@@ -409,6 +414,7 @@ export function correctHours(entries, shiftTypes, shiftMap, currentHours, target
     let deficit = Math.abs(diff);
     for (const entry of offEntries) {
       if (deficit <= 0) break;
+      if (lockedOffDates.has(entry.date)) continue; // preserva folga semanal obrigatória
       entry.is_day_off = 0;
       entry.shift_type_id = shiftToAdd.id;
       deficit -= shiftToAdd.duration_hours;

--- a/backend/src/tests/scheduleGenerator.unit.test.js
+++ b/backend/src/tests/scheduleGenerator.unit.test.js
@@ -4,7 +4,7 @@ import { isValidEmendado, correctHours } from '../services/scheduleGenerator.js'
 describe('isValidEmendado', () => {
   it('permite Tarde → Noturno', () => expect(isValidEmendado('Tarde', 'Noturno')).toBe(true));
   it('permite Noturno → Manhã', () => expect(isValidEmendado('Noturno', 'Manhã')).toBe(true));
-  it('bloqueia Manhã → Tarde', () => expect(isValidEmendado('Manhã', 'Tarde')).toBe(false));
+  it('permite Manhã → Tarde (emendado diurno, regra 11)', () => expect(isValidEmendado('Manhã', 'Tarde')).toBe(true));
   it('bloqueia Noturno → Noturno', () => expect(isValidEmendado('Noturno', 'Noturno')).toBe(false));
   it('bloqueia Tarde → Manhã', () => expect(isValidEmendado('Tarde', 'Manhã')).toBe(false));
   it('retorna false para valores nulos', () => expect(isValidEmendado(null, 'Noturno')).toBe(false));


### PR DESCRIPTION
## Problema

Após o merge do PR #8, 4 testes falhavam:

1. **`scheduleGenerator.unit.test.js`** — `isValidEmendado('Manhã', 'Tarde')` retornava `true` mas o teste esperava `false`
2. **`scheduleRules.test.js`** — `res.body.warnings` era `undefined` em 2 testes de integração
3. **`scheduleRules.test.js`** — `folga semanal`: `correctHours` convertia folgas semanais obrigatórias em trabalho, violando a regra 6

## Causa raiz

- **Teste #1**: PR #8 adicionou `['Manhã', 'Tarde']` ao `EMENDADO_PAIRS` (regra 11), tornando `isValidEmendado('Manhã', 'Tarde') = true`. O teste não foi atualizado para refletir a nova regra.
- **Testes #3 e #4**: A rota `POST /api/schedules/generate` era síncrona mas `generateSchedule` se tornou `async` no PR #8. Sem `await`, `result` era uma Promise e `res.body.warnings` ficava `undefined`.
- **Teste #2**: `correctHours` convertia folgas planejadas semanalmente (`selectedOff`) em dias de trabalho ao compensar déficit de horas, violando a regra 6 (mínimo 1 folga/semana). O padrão de emendado Noturno→Manhã (adicionado no PR #8) gera menos horas por slot de trabalho do que o esperado (18h em 2 slots vs 12h/slot), ampliando o déficit.

## Correções

| Arquivo | Mudança |
|---------|----------|
| `backend/src/routes/schedules.js` | `async`/`await` no handler `POST /generate` |
| `backend/src/services/scheduleGenerator.js` | `correctHours` aceita `lockedOffDates` (Set) e pula esses dias na conversão; `generateForEmployee` coleta `weeklyOffDates` e os passa ao passo de correção |
| `backend/src/tests/scheduleGenerator.unit.test.js` | Atualiza `'bloqueia Manhã → Tarde'` → `'permite Manhã → Tarde (emendado diurno, regra 11)'` com `toBe(true)` |

## Evidência

```
✓ src/tests/scheduleGenerator.unit.test.js (9 tests)
✓ src/tests/scheduleRules.test.js (6 tests)
Test Files  2 passed (2)
      Tests  15 passed (15)
```

🤖 Desenvolvedor Pleno