### PR TITLE
fix: seg_sex forcedOff nao protegido contra correctHours (closes #13)

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -157,8 +157,15 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
   let lastShiftName = null;
   let consecutiveHours = 0;
   const entries = [];
-  // Vacation and other forced-off dates — preserved by correctHours
-  const lockedOffDates = new Set(vacationDatesForEmp);
+  // Vacation and seg_sex forced-off weekend dates — preserved by correctHours
+  const segSexForcedOff = isSegSex
+    ? new Set(dates.filter((d) => {
+        if (lockedDates.has(d) || vacationDatesForEmp.has(d)) return false;
+        const dow = new Date(d + 'T12:00:00').getDay();
+        return dow === 0 || dow === 6;
+      }))
+    : new Set();
+  const lockedOffDates = new Set([...vacationDatesForEmp, ...segSexForcedOff]);
 
   // Count locked hours
   for (const entry of lockedEntries) {

--- a/backend/src/tests/newRules.test.js
+++ b/backend/src/tests/newRules.test.js
@@ -27,16 +27,11 @@ describe('Regra 12 — work_schedule seg_sex: Sáb/Dom viram folga obrigatória'
     expect(res.status).toBe(400);
   });
 
-  it.skip('gerador marca Domingos como folga para funcionário seg_sex (Domingos nunca são alvo de enforcement)', async () => {
-    // BUG CONHECIDO no gerador (ver issue #12):
-    // `correctHours` pode converter Domingos de volta a plantão quando o funcionário
-    // tem horas insuficientes. O problema está em `lockedOffDates` (scheduleGenerator.js:161)
-    // que só inclui `vacationDatesForEmp`, mas não os dias `seg_sex` forcedOff.
-    // O enforcement (enforceNocturnalCoverage) de fato pula Domingos (dow=0),
-    // mas `correctHours` não tem esse guard. Fix: adicionar forcedOff a lockedOffDates.
-    //
+  it('gerador marca Domingos como folga para funcionário seg_sex (Domingos nunca são alvo de enforcement)', async () => {
     // Domingos (dow=0) não têm requisito de cobertura nas Regras 21/22,
     // portanto nunca são convertidos pelo enforcement — assert 100% seguro.
+    // Fix aplicado (issue #13): segSexForcedOff agora integra lockedOffDates,
+    // impedindo que correctHours converta fins-de-semana de volta a plantão.
     const empRes = await request(app).post('/api/employees').send({
       name: 'Bruno',
       setores: ['Transporte Ambulância'],


### PR DESCRIPTION
## Problema

`correctHours` podia converter Domingos/Sábados de funcionários `seg_sex` de volta a plantão quando o total de horas estava abaixo de 160h. O `lockedOffDates` só continha `vacationDatesForEmp`, deixando os fins de semana `forcedOff` desprotegidos.

## Fix

`scheduleGenerator.js` — antes do loop de semanas, calcula todos os fins de semana `seg_sex` do mês e os adiciona ao `lockedOffDates`:

```js
const segSexForcedOff = isSegSex
  ? new Set(dates.filter((d) => {
      if (lockedDates.has(d) || vacationDatesForEmp.has(d)) return false;
      const dow = new Date(d + 'T12:00:00').getDay();
      return dow === 0 || dow === 6;
    }))
  : new Set();
const lockedOffDates = new Set([...vacationDatesForEmp, ...segSexForcedOff]);
```

## Evidência

- `it.skip` removido de `newRules.test.js`
- `npm test` local: **85/85 passed, 0 skipped, 0 failed**

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)