### PR TITLE
fix: guard seg_sex employees from enforcement conversion on Saturday (issue #18)

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -515,6 +515,8 @@ function enforceDiurnoCoverage(db, employees, employeeSectorsMap, dates, diurnoS
         if (fixed >= needed) break;
         const setores = employeeSectorsMap[emp.id] || [];
         if (!setores.includes(SETOR_HEMO)) continue;
+        // Regra 12: seg_sex nunca trabalha Sábado (dow=6); domingo já é excluído acima.
+        if (emp.work_schedule === 'seg_sex' && dow === 6) continue;
         const entry = entryByEmp[emp.id];
         if (!entry || !entry.is_day_off || entry.is_locked || entry.notes === 'Férias') continue;
         if (!canAssignShift(db, emp.id, date, diurnoShift)) continue;
@@ -555,6 +557,8 @@ function enforceDiurnoCoverage(db, employees, employeeSectorsMap, dates, diurnoS
         if (fixed) break;
         const setores = employeeSectorsMap[emp.id] || [];
         if (!setores.includes(SETOR_AMBUL)) continue;
+        // Regra 12: seg_sex nunca trabalha Sábado (dow=6); domingo já é excluído acima.
+        if (emp.work_schedule === 'seg_sex' && dow === 6) continue;
         const entry = entryByEmp[emp.id];
         if (!entry || !entry.is_day_off || entry.is_locked || entry.notes === 'Férias') continue;
         if (!canAssignShift(db, emp.id, date, diurnoShift)) continue;
@@ -618,6 +622,8 @@ function enforceNocturnalCoverage(db, employees, employeeSectorsMap, dates, notu
         if (fixed >= needed) break;
         const setores = employeeSectorsMap[emp.id] || [];
         if (!setores.includes(SETOR_AMBUL)) continue;
+        // Regra 12: seg_sex nunca trabalha Sábado (dow=6); domingo já tem required=0 acima.
+        if (emp.work_schedule === 'seg_sex' && dow === 6) continue;
         const entry = entryByEmp[emp.id];
         if (!entry || !entry.is_day_off || entry.is_locked || entry.notes === 'Férias') continue;
         if (!canAssignShift(db, emp.id, date, noturnoShift)) continue;

--- a/backend/src/tests/newRules.test.js
+++ b/backend/src/tests/newRules.test.js
@@ -51,6 +51,30 @@ describe('Regra 12 — work_schedule seg_sex: Sáb/Dom viram folga obrigatória'
     });
   });
 
+  it('gerador marca Sábados como folga para funcionário seg_sex — enforcement não converte (issue #18)', async () => {
+    // Mesmo que enforcement (Regras 16/21/22) precise de cobertura no Sábado,
+    // um funcionário seg_sex nunca pode ser convertido nesse dia.
+    // Fix aplicado (issue #18): guard `emp.work_schedule === 'seg_sex' && dow === 6`
+    // adicionado em enforceDiurnoCoverage e enforceNocturnalCoverage.
+    const empRes = await request(app).post('/api/employees').send({
+      name: 'Bruno Sab',
+      setores: ['Transporte Ambulância'],
+      work_schedule: 'seg_sex',
+    });
+    expect(empRes.status).toBe(201);
+
+    await request(app).post('/api/schedules/generate').send({ month: 1, year: 2025 });
+
+    const schedule = await request(app).get('/api/schedules?month=1&year=2025');
+    const entries = schedule.body.entries.filter((e) => e.employee_id === empRes.body.id);
+
+    const saturdayEntries = entries.filter((e) => new Date(e.date + 'T12:00:00').getDay() === 6);
+    expect(saturdayEntries.length).toBeGreaterThan(0); // Janeiro 2025 tem 4 sábados
+    saturdayEntries.forEach((e) => {
+      expect(e.is_day_off).toBe(1);
+    });
+  });
+
   it('funcionário seg_sex tem mais folgas em fins-de-semana que funcionário dom_sab equivalente', async () => {
     // Cria seg_sex e dom_sab com mesmo setor; compara contagem de folgas em Sáb/Dom
     const resSeg = await request(app).post('/api/employees').send({


### PR DESCRIPTION
## Problema

Funcionários `work_schedule=seg_sex` (Regra 12) nunca deveriam trabalhar Sábado ou Domingo. O fix do PR #14 corrigiu `correctHours` via `lockedOffDates`. Porém, `enforceDiurnoCoverage` (Regra 16) e `enforceNocturnalCoverage` (Regras 21/22) ainda podiam converter uma folga de **Sábado** de um funcionário `seg_sex` em plantão para suprir cobertura.

Domingo já era seguro: Diurno pula Sunday no nível da data (`dow === 0` skip); Noturno tem `required=0` para Sunday — portanto apenas **Sábado** precisava do guard.

## Solução

Guard `emp.work_schedule === 'seg_sex' && dow === 6` adicionado em 3 pontos dos loops de candidato:

- `enforceDiurnoCoverage` → loop fix Hemo (≥2)
- `enforceDiurnoCoverage` → loop fix Ambul (≥1)
- `enforceNocturnalCoverage` → loop fix Ambul (≥1 ou ≥2)

## Plano de teste

Cenário: funcionário `seg_sex` único em Ambulância → enforcement tenta suprir cobertura de Sábado → guard impede → todos os Sábados permanecem `is_day_off=1`.

## Logs de execução

```
Test Files  6 passed (6)
      Tests  86 passed (86)
   Duration  1.44s
```

## Taxa de sucesso

86/86 (100%) — zero regressões.

Closes #18

---
*Desenvolvedor Pleno*