### PR TITLE
fix: sync shift_type_id in-memory after enforcement conversions (issue #17)

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -526,6 +526,7 @@ function enforceDiurnoCoverage(db, employees, employeeSectorsMap, dates, diurnoS
         ).run(diurnoShift.id, entry.id);
         entry.is_day_off = 0;
         entry.shift_name = SHIFT_DIURNO_NAME;
+        entry.shift_type_id = diurnoShift.id;
         fixed++;
       }
       if (hemoCount + fixed < 2) {
@@ -566,6 +567,9 @@ function enforceDiurnoCoverage(db, employees, employeeSectorsMap, dates, diurnoS
         db.prepare(
           'UPDATE schedule_entries SET is_day_off = 0, shift_type_id = ? WHERE id = ?'
         ).run(diurnoShift.id, entry.id);
+        entry.is_day_off = 0;
+        entry.shift_name = SHIFT_DIURNO_NAME;
+        entry.shift_type_id = diurnoShift.id;
         fixed = true;
       }
       if (!fixed) {
@@ -633,6 +637,7 @@ function enforceNocturnalCoverage(db, employees, employeeSectorsMap, dates, notu
         ).run(noturnoShift.id, entry.id);
         entry.is_day_off = 0;
         entry.shift_name = SHIFT_NOTURNO_NAME;
+        entry.shift_type_id = noturnoShift.id;
         fixed++;
       }
       if (ambulNoturno + fixed < required) {

--- a/backend/src/tests/scheduleRules.test.js
+++ b/backend/src/tests/scheduleRules.test.js
@@ -168,4 +168,29 @@ describe('Regra 5 — cobertura diurna mínima (Regra 16)', () => {
     // 1 motorista não consegue cobrir todos os dias que exigem ≥2 Ambulância
     expect(nightWarnings.length).toBeGreaterThan(0);
   });
+
+  it('entries convertidas pelo enforcement têm shift_type_id consistente com shift_name (issue #17)', async () => {
+    // Issue #17: após enforcement converter uma folga em plantão, a cópia em
+    // memória não atualizava shift_type_id (nem is_day_off/shift_name no bloco
+    // Ambul diurno). Garante invariante: shift_type_id e shift_name são coerentes
+    // em todas as entries de plantão.
+    const db = freshDb();
+    createEmployee(db, { name: 'HemoA', setor: 'Transporte Hemodiálise' });
+    createEmployee(db, { name: 'HemoB', setor: 'Transporte Hemodiálise' });
+    createEmployee(db, { name: 'AmbuA', setor: 'Transporte Ambulância' });
+
+    await request(app).post('/api/schedules/generate').send({ month: 1, year: 2025 });
+
+    const shiftsRes = await request(app).get('/api/shift-types');
+    const shiftById = {};
+    for (const s of shiftsRes.body) shiftById[s.id] = s.name;
+
+    const schedule = await request(app).get('/api/schedules?month=1&year=2025');
+    const workEntries = schedule.body.entries.filter((e) => !e.is_day_off);
+
+    expect(workEntries.length).toBeGreaterThan(0);
+    workEntries.forEach((e) => {
+      expect(shiftById[e.shift_type_id]).toBe(e.shift_name);
+    });
+  });
 });


### PR DESCRIPTION
## Problema

Issue #17: após `enforceDiurnoCoverage` e `enforceNocturnalCoverage` converterem uma folga em plantão, a cópia **em memória** da entry não era completamente sincronizada:

| Bloco | is_day_off | shift_name | shift_type_id |
|-------|-----------|------------|---------------|
| Hemo diurno | ✅ | ✅ | ❌ faltava |
| Ambul diurno | ❌ faltava | ❌ faltava | ❌ faltava |
| Ambul noturno | ✅ | ✅ | ❌ faltava |

Embora o DB fosse sempre escrito corretamente, a cópia em memória inconsistente é um risco de manutenção: código futuro que leia `entry.shift_type_id` após uma conversão obteria o valor antigo (ID do turno anterior ou null).

## Solução

Adicionado `entry.shift_type_id = <shift>.id` nos 3 blocos de conversão. No bloco Ambul diurno, adicionados também `entry.is_day_off = 0` e `entry.shift_name` para consistência completa.

## Plano de teste

Cenário: 2 Hemo + 1 Ambul → enforcement Diurno executa → schedule gerado → todas as entries de plantão têm `shift_type_id` coerente com `shift_name`.

## Logs de execução

```
Test Files  6 passed (6)
      Tests  87 passed (87)
   Duration  1.52s
```

## Taxa de sucesso

87/87 (100%) — zero regressões.

Closes #17

---
*Desenvolvedor Pleno*