### PR TITLE
fix: normalize setor_override empty string to null in PUT /entry/:id (issue #15)

### DIFF
--- a/backend/src/routes/schedules.js
+++ b/backend/src/routes/schedules.js
@@ -88,7 +88,9 @@ router.post('/generate', async (req, res) => {
 // PUT /api/schedules/entry/:id
 router.put('/entry/:id', (req, res) => {
   const db = getDb();
-  const { shift_type_id, is_day_off, is_locked, notes, setor_override } = req.body;
+  const { shift_type_id, is_day_off, is_locked, notes } = req.body;
+  // Normalizar string vazia para null — "" não é um setor válido e não deve ser gravado no DB.
+  const setor_override = req.body.setor_override === '' ? null : req.body.setor_override;
   const id = parseInt(req.params.id);
 
   const entry = db

--- a/backend/src/tests/schedules.test.js
+++ b/backend/src/tests/schedules.test.js
@@ -144,6 +144,73 @@ describe('PUT /api/schedules/entry/:id', () => {
     expect(res.status).toBe(200);
     expect(res.body.notes).toBe('Licença médica');
   });
+
+  it('setor_override "" é normalizado para null (issue #15)', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Eduardo', setores: ['Transporte Ambulância'] });
+
+    const result = db
+      .prepare('INSERT INTO schedule_entries (employee_id, date, is_day_off, setor_override) VALUES (?, ?, 0, ?)')
+      .run(emp.id, '2025-03-15', 'Transporte Ambulância');
+
+    const res = await request(app)
+      .put(`/api/schedules/entry/${result.lastInsertRowid}`)
+      .send({ setor_override: '' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.setor_override).toBeNull();
+  });
+
+  it('setor_override null limpa o override existente', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Flávia', setores: ['Transporte Ambulância'] });
+
+    const result = db
+      .prepare('INSERT INTO schedule_entries (employee_id, date, is_day_off, setor_override) VALUES (?, ?, 0, ?)')
+      .run(emp.id, '2025-03-16', 'Transporte Ambulância');
+
+    const res = await request(app)
+      .put(`/api/schedules/entry/${result.lastInsertRowid}`)
+      .send({ setor_override: null });
+
+    expect(res.status).toBe(200);
+    expect(res.body.setor_override).toBeNull();
+  });
+
+  it('setor_override válido é aceito e persistido', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, {
+      name: 'Gustavo',
+      setores: ['Transporte Ambulância', 'Transporte Hemodiálise'],
+    });
+
+    const result = db
+      .prepare('INSERT INTO schedule_entries (employee_id, date, is_day_off) VALUES (?, ?, 0)')
+      .run(emp.id, '2025-03-17');
+
+    const res = await request(app)
+      .put(`/api/schedules/entry/${result.lastInsertRowid}`)
+      .send({ setor_override: 'Transporte Hemodiálise' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.setor_override).toBe('Transporte Hemodiálise');
+  });
+
+  it('setor_override inválido (não pertence ao funcionário) retorna 400', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Helena', setores: ['Transporte Ambulância'] });
+
+    const result = db
+      .prepare('INSERT INTO schedule_entries (employee_id, date, is_day_off) VALUES (?, ?, 0)')
+      .run(emp.id, '2025-03-18');
+
+    const res = await request(app)
+      .put(`/api/schedules/entry/${result.lastInsertRowid}`)
+      .send({ setor_override: 'Transporte Hemodiálise' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/setor_override/i);
+  });
 });
 
 describe('DELETE /api/schedules/month', () => {


### PR DESCRIPTION
## Problema

Issue #15: enviar `setor_override: ""` no `PUT /api/schedules/entry/:id` deveria limpar o override (equivalente a `null`). Antes:

1. **Validação incorreta**: a string vazia passava pelo guard `setor_override !== null && setor_override !== undefined`, tentava checar se `""` pertencia aos setores do funcionário, e retornava **400** — comportamento errado para uma operação de limpeza.
2. **Escrita incorreta**: se a validação fosse contornada, gravaria `""` (string vazia) no DB em vez de `NULL`.

## Solução

Normalizar `req.body.setor_override === ''` para `null` logo após o destructuring, antes de qualquer validação ou escrita no banco:

```js
const setor_override = req.body.setor_override === '' ? null : req.body.setor_override;
```

Assim, `""` e `null` têm o mesmo efeito: limpar o campo no DB.

## Plano de teste

4 casos adicionados em `schedules.test.js`:
- `""` → normalizado para `null` ✅ (caso principal)
- `null` → limpa override existente ✅
- setor válido do funcionário → aceito e persistido ✅
- setor inválido → retorna 400 ✅

## Logs de execução

```
Test Files  6 passed (6)
      Tests  91 passed (91)
   Duration  1.32s
```

## Taxa de sucesso

91/91 (100%) — zero regressões.

Closes #15

---
*Desenvolvedor Pleno*