### PR TITLE
test: edge cases complementares para issues #15 e #18

### DIFF
--- a/backend/src/tests/newRules.test.js
+++ b/backend/src/tests/newRules.test.js
@@ -75,6 +75,27 @@ describe('Regra 12 — work_schedule seg_sex: Sáb/Dom viram folga obrigatória'
     });
   });
 
+  it('warning emitido quando único candidato de Sábado noturno é seg_sex (guard não deve silenciar warning)', async () => {
+    // Quando o guard bloqueia a conversão de um seg_sex no Sábado, o enforcement
+    // não encontra candidatos e DEVE emitir um warning noturno_ambul para esse dia.
+    // Isso garante que o guard não esconde problemas reais de cobertura.
+    const empRes = await request(app).post('/api/employees').send({
+      name: 'Único SegSex',
+      setores: ['Transporte Ambulância'],
+      work_schedule: 'seg_sex',
+    });
+    expect(empRes.status).toBe(201);
+
+    const genRes = await request(app).post('/api/schedules/generate').send({ month: 1, year: 2025 });
+
+    // Sábados com requisito ≥2 Ambul noturno (Ter/Qui/Sáb = dow 2,4,6)
+    // O único funcionário é seg_sex, portanto não pode ser convertido no Sábado.
+    const satWarnings = genRes.body.warnings.filter(
+      (w) => w.type === 'noturno_ambul' && new Date(w.date + 'T12:00:00').getDay() === 6
+    );
+    expect(satWarnings.length).toBeGreaterThan(0);
+  });
+
   it('funcionário seg_sex tem mais folgas em fins-de-semana que funcionário dom_sab equivalente', async () => {
     // Cria seg_sex e dom_sab com mesmo setor; compara contagem de folgas em Sáb/Dom
     const resSeg = await request(app).post('/api/employees').send({

--- a/backend/src/tests/schedules.test.js
+++ b/backend/src/tests/schedules.test.js
@@ -211,6 +211,26 @@ describe('PUT /api/schedules/entry/:id', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/setor_override/i);
   });
+
+  it('omitir setor_override não altera valor existente (no-op)', async () => {
+    // Garante que o guard `setor_override !== undefined` funciona corretamente:
+    // campos não enviados no payload não devem sobrescrever o valor no DB.
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Igor', setores: ['Transporte Ambulância'] });
+
+    const result = db
+      .prepare('INSERT INTO schedule_entries (employee_id, date, is_day_off, setor_override) VALUES (?, ?, 0, ?)')
+      .run(emp.id, '2025-03-19', 'Transporte Ambulância');
+
+    // Atualiza apenas notes — setor_override não enviado
+    const res = await request(app)
+      .put(`/api/schedules/entry/${result.lastInsertRowid}`)
+      .send({ notes: 'Observação' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.setor_override).toBe('Transporte Ambulância'); // inalterado
+    expect(res.body.notes).toBe('Observação');
+  });
 });
 
 describe('DELETE /api/schedules/month', () => {


### PR DESCRIPTION
## Contexto

PRs #20, #21 e #22 adicionaram testes junto com cada fix. O Tester Senior verificou a cobertura existente (91/91 passando) e identificou 2 edge cases não cobertos pelo Dev.

## Gaps identificados e cobertos

### Issue #15 — `setor_override` normalization
**Gap**: nenhum teste verificava que **omitir** `setor_override` no payload mantém o valor existente (comportamento no-op). Isso testa o guard `setor_override !== undefined` que protege o campo de sobrescrita acidental.

Teste adicionado: *"omitir setor_override não altera valor existente (no-op)"*

### Issue #18 — seg_sex enforcement guard
**Gap**: o guard bloqueia a conversão de um `seg_sex` no Sábado, mas **o warning de cobertura insuficiente deve ser emitido** quando não há outros candidatos. Sem este teste, uma regressão que silenciasse o warning passaria despercebida.

Teste adicionado: *"warning emitido quando único candidato de Sábado noturno é seg_sex"*

## Logs de execução

```
Test Files  6 passed (6)
      Tests  93 passed (93)
   Duration  1.30s
```

## Taxa de sucesso

93/93 (100%) — 2 novos edge cases, zero regressões.

---
*Tester Senior*