### PR TITLE
fix(generator): iteração DST-safe para datas de férias (issue #16)

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -70,11 +70,11 @@ export async function generateSchedule({ month, year, overwriteLocked = false })
       .prepare('SELECT employee_id, start_date, end_date FROM employee_vacations')
       .all();
     for (const v of vacRows) {
-      let d = new Date(v.start_date + 'T12:00:00');
-      const end = new Date(v.end_date + 'T12:00:00');
-      while (d <= end) {
-        allVacationDates.add(`${v.employee_id}:${format(d, 'yyyy-MM-dd')}`);
-        d = new Date(d.getTime() + 24 * 60 * 60 * 1000);
+      let cursor = v.start_date;
+      while (cursor <= v.end_date) {
+        allVacationDates.add(`${v.employee_id}:${cursor}`);
+        const [y, m, day] = cursor.split('-').map(Number);
+        cursor = new Date(Date.UTC(y, m - 1, day + 1)).toISOString().slice(0, 10);
       }
     }
   }


### PR DESCRIPTION
## Contexto

Fecha #16. A iteração sobre os dias de férias em `scheduleGenerator.js` usava aritmética de milissegundos (`getTime() + 86400000`) para avançar um dia. Em fusos com DST, isso pode pular ou duplicar um dia de férias durante a transição do horário de verão.

## Causa raiz

```js
// ANTES — DST-unsafe
let d = new Date(v.start_date + 'T12:00:00');
const end = new Date(v.end_date + 'T12:00:00');
while (d <= end) {
  allVacationDates.add(`${v.employee_id}:${format(d, 'yyyy-MM-dd')}`);
  d = new Date(d.getTime() + 24 * 60 * 60 * 1000); // pode pular/duplicar em DST
}
```

## Fix aplicado

```js
// DEPOIS — DST-safe (string cursor + Date.UTC)
let cursor = v.start_date;
while (cursor <= v.end_date) {
  allVacationDates.add(`${v.employee_id}:${cursor}`);
  const [y, m, day] = cursor.split('-').map(Number);
  cursor = new Date(Date.UTC(y, m - 1, day + 1)).toISOString().slice(0, 10);
}
```

`Date.UTC` opera sempre em UTC, sem influência de timezone local. A comparação `cursor <= v.end_date` funciona corretamente com strings ISO (`YYYY-MM-DD` ordena lexicograficamente igual a cronologicamente). Nenhum objeto Date com timezone local é usado no loop.

## Plano de teste

- Todos os 93 testes existentes devem continuar passando (incluindo os de férias em `newRules.test.js`)
- Comportamento em ambiente UTC (servidor em produção) é idêntico ao anterior
- A mudança é transparente para o usuário final

## Logs de execução

```
Test Files  6 passed (6)
      Tests  93 passed (93)
   Duration  2.17s
```

## Taxa de sucesso

93/93 (100%) — zero regressões.

---
*Desenvolvedor Pleno*