### PR TITLE
test(frontend): testes de ConfirmDialog e EmployeeForm (34 testes)

### DIFF
--- a/frontend/src/tests/ConfirmDialog.test.jsx
+++ b/frontend/src/tests/ConfirmDialog.test.jsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ConfirmDialog from '../components/shared/ConfirmDialog.jsx';
+
+const defaultProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  title: 'Confirmar exclusão',
+  description: 'Esta ação não pode ser desfeita.',
+  onConfirm: vi.fn(),
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('ConfirmDialog — renderização', () => {
+  it('exibe title e description quando open=true', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByText('Confirmar exclusão')).toBeInTheDocument();
+    expect(screen.getByText('Esta ação não pode ser desfeita.')).toBeInTheDocument();
+  });
+
+  it('exibe botão Cancelar', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Cancelar' })).toBeInTheDocument();
+  });
+
+  it('usa confirmLabel padrão "Confirmar"', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Confirmar' })).toBeInTheDocument();
+  });
+
+  it('usa confirmLabel customizado', () => {
+    render(<ConfirmDialog {...defaultProps} confirmLabel="Excluir permanentemente" />);
+    expect(screen.getByRole('button', { name: 'Excluir permanentemente' })).toBeInTheDocument();
+  });
+
+  it('não exibe conteúdo quando open=false', () => {
+    render(<ConfirmDialog {...defaultProps} open={false} />);
+    expect(screen.queryByText('Confirmar exclusão')).not.toBeInTheDocument();
+  });
+});
+
+describe('ConfirmDialog — variant', () => {
+  it('variant="danger" aplica classe btn-danger no botão de confirmação', () => {
+    render(<ConfirmDialog {...defaultProps} variant="danger" />);
+    expect(screen.getByRole('button', { name: 'Confirmar' })).toHaveClass('btn-danger');
+  });
+
+  it('variant diferente de danger aplica classe btn-primary', () => {
+    render(<ConfirmDialog {...defaultProps} variant="primary" />);
+    expect(screen.getByRole('button', { name: 'Confirmar' })).toHaveClass('btn-primary');
+  });
+
+  it('variant padrão (não informado) usa btn-danger', () => {
+    const { onOpenChange, onConfirm, ...rest } = defaultProps;
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onConfirm={vi.fn()}
+        title="T"
+        description="D"
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Confirmar' })).toHaveClass('btn-danger');
+  });
+});
+
+describe('ConfirmDialog — interações', () => {
+  it('clicar em confirmar chama onConfirm exatamente uma vez', () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmDialog {...defaultProps} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Confirmar' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicar em confirmar chama onOpenChange(false) para fechar o dialog', () => {
+    const onOpenChange = vi.fn();
+    render(<ConfirmDialog {...defaultProps} onOpenChange={onOpenChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Confirmar' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('clicar em confirmar chama onConfirm antes de fechar', () => {
+    const callOrder = [];
+    const onConfirm = vi.fn(() => callOrder.push('confirm'));
+    const onOpenChange = vi.fn((v) => { if (v === false) callOrder.push('close'); });
+    render(<ConfirmDialog {...defaultProps} onConfirm={onConfirm} onOpenChange={onOpenChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Confirmar' }));
+    expect(callOrder).toEqual(['confirm', 'close']);
+  });
+});

--- a/frontend/src/tests/EmployeeForm.test.jsx
+++ b/frontend/src/tests/EmployeeForm.test.jsx
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EmployeeForm from '../components/employees/EmployeeForm.jsx';
+import useStore from '../store/useStore.js';
+
+vi.mock('../store/useStore.js', () => ({ default: vi.fn() }));
+
+const mockStore = {
+  shiftTypes: [],
+  createEmployee: vi.fn(),
+  updateEmployee: vi.fn(),
+  createVacation: vi.fn(),
+  deleteVacation: vi.fn(),
+  addToast: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useStore.mockReturnValue(mockStore);
+  mockStore.createEmployee.mockResolvedValue({ id: 99, name: 'Novo' });
+  mockStore.updateEmployee.mockResolvedValue({ id: 1, name: 'Atualizado' });
+  mockStore.createVacation.mockResolvedValue({ id: 10, start_date: '2025-01-01', end_date: '2025-01-07' });
+  mockStore.deleteVacation.mockResolvedValue({});
+});
+
+const openProps = { open: true, onOpenChange: vi.fn(), onSuccess: vi.fn() };
+
+// ─── Renderização ─────────────────────────────────────────────────────────────
+
+describe('EmployeeForm — renderização', () => {
+  it('exibe "Novo Funcionário" no modo criação (sem employee prop)', () => {
+    render(<EmployeeForm {...openProps} />);
+    expect(screen.getByText('Novo Funcionário')).toBeInTheDocument();
+  });
+
+  it('exibe "Editar Funcionário" no modo edição (com employee prop)', () => {
+    const employee = { id: 1, name: 'Ana', setores: ['Transporte Ambulância'], vacations: [] };
+    render(<EmployeeForm {...openProps} employee={employee} />);
+    expect(screen.getByText('Editar Funcionário')).toBeInTheDocument();
+  });
+
+  it('botão submit exibe "Criar" no modo criação', () => {
+    render(<EmployeeForm {...openProps} />);
+    expect(screen.getByRole('button', { name: 'Criar' })).toBeInTheDocument();
+  });
+
+  it('botão submit exibe "Salvar" no modo edição', () => {
+    const employee = { id: 1, name: 'Ana', setores: ['Transporte Ambulância'], vacations: [] };
+    render(<EmployeeForm {...openProps} employee={employee} />);
+    expect(screen.getByRole('button', { name: 'Salvar' })).toBeInTheDocument();
+  });
+
+  it('seção Férias visível apenas no modo edição', () => {
+    const employee = { id: 1, name: 'Ana', setores: ['Transporte Ambulância'], vacations: [] };
+    const { rerender } = render(<EmployeeForm {...openProps} />);
+    expect(screen.queryByText('Férias')).not.toBeInTheDocument();
+
+    rerender(<EmployeeForm {...openProps} employee={employee} />);
+    expect(screen.getByText('Férias')).toBeInTheDocument();
+  });
+
+  it('cargo exibido como texto fixo "Motorista"', () => {
+    render(<EmployeeForm {...openProps} />);
+    expect(screen.getByText('Motorista')).toBeInTheDocument();
+  });
+
+  it('descanso mínimo exibido como texto fixo "24h"', () => {
+    render(<EmployeeForm {...openProps} />);
+    expect(screen.getByText('24h')).toBeInTheDocument();
+  });
+
+  it('não exibe conteúdo quando open=false', () => {
+    render(<EmployeeForm open={false} onOpenChange={vi.fn()} />);
+    expect(screen.queryByText('Novo Funcionário')).not.toBeInTheDocument();
+  });
+});
+
+// ─── toggleSetor — lógica de exclusividade ADM ────────────────────────────────
+
+describe('EmployeeForm — toggleSetor', () => {
+  it('selecionar Ambulância marca apenas Ambulância', () => {
+    render(<EmployeeForm {...openProps} />);
+    const cbAmbul = screen.getByRole('checkbox', { name: /Ambulância/ });
+    fireEvent.click(cbAmbul);
+    expect(cbAmbul).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Hemodiálise/ })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Administrativo/ })).not.toBeChecked();
+  });
+
+  it('selecionar Ambulância + Hemodiálise → ambos marcados simultaneamente', () => {
+    render(<EmployeeForm {...openProps} />);
+    fireEvent.click(screen.getByRole('checkbox', { name: /Ambulância/ }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /Hemodiálise/ }));
+    expect(screen.getByRole('checkbox', { name: /Ambulância/ })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Hemodiálise/ })).toBeChecked();
+  });
+
+  it('desselecionar Ambulância já marcada remove a seleção', () => {
+    render(<EmployeeForm {...openProps} />);
+    const cb = screen.getByRole('checkbox', { name: /Ambulância/ });
+    fireEvent.click(cb);
+    fireEvent.click(cb);
+    expect(cb).not.toBeChecked();
+  });
+
+  it('selecionar ADM quando Ambulância está marcada: ADM fica marcado, Ambulância desmarcada', () => {
+    render(<EmployeeForm {...openProps} />);
+    fireEvent.click(screen.getByRole('checkbox', { name: /Ambulância/ }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /Administrativo/ }));
+    expect(screen.getByRole('checkbox', { name: /Administrativo/ })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Ambulância/ })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Hemodiálise/ })).not.toBeChecked();
+  });
+
+  it('selecionar ADM quando nada está marcado: ADM fica marcado', () => {
+    render(<EmployeeForm {...openProps} />);
+    fireEvent.click(screen.getByRole('checkbox', { name: /Administrativo/ }));
+    expect(screen.getByRole('checkbox', { name: /Administrativo/ })).toBeChecked();
+  });
+
+  it('desselecionar ADM quando ADM está marcado: todos ficam desmarcados', () => {
+    render(<EmployeeForm {...openProps} />);
+    const cbAdm = screen.getByRole('checkbox', { name: /Administrativo/ });
+    fireEvent.click(cbAdm); // seleciona
+    fireEvent.click(cbAdm); // desseleciona
+    expect(cbAdm).not.toBeChecked();
+  });
+
+  it('checkboxes de Ambulância e Hemodiálise ficam disabled quando ADM está selecionado', () => {
+    render(<EmployeeForm {...openProps} />);
+    fireEvent.click(screen.getByRole('checkbox', { name: /Administrativo/ }));
+    expect(screen.getByRole('checkbox', { name: /Ambulância/ })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: /Hemodiálise/ })).toBeDisabled();
+  });
+
+  it('checkboxes de Ambulância e Hemodiálise ficam enabled quando ADM é desselecionado', () => {
+    render(<EmployeeForm {...openProps} />);
+    const cbAdm = screen.getByRole('checkbox', { name: /Administrativo/ });
+    fireEvent.click(cbAdm);
+    fireEvent.click(cbAdm);
+    expect(screen.getByRole('checkbox', { name: /Ambulância/ })).not.toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: /Hemodiálise/ })).not.toBeDisabled();
+  });
+
+  it('aviso de setor obrigatório exibido quando nenhum setor está selecionado', () => {
+    render(<EmployeeForm {...openProps} />);
+    expect(screen.getByText('Selecione pelo menos um setor')).toBeInTheDocument();
+  });
+
+  it('aviso de setor obrigatório some após selecionar um setor', () => {
+    render(<EmployeeForm {...openProps} />);
+    fireEvent.click(screen.getByRole('checkbox', { name: /Ambulância/ }));
+    expect(screen.queryByText('Selecione pelo menos um setor')).not.toBeInTheDocument();
+  });
+});
+
+// ─── Submit — validação e payload ────────────────────────────────────────────
+
+describe('EmployeeForm — submit', () => {
+  it('submit sem setores exibe toast de erro e não chama createEmployee', async () => {
+    const user = userEvent.setup();
+    render(<EmployeeForm {...openProps} />);
+
+    await user.type(screen.getByPlaceholderText('Nome completo'), 'João');
+    await user.click(screen.getByRole('button', { name: 'Criar' }));
+
+    expect(mockStore.addToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' })
+    );
+    expect(mockStore.createEmployee).not.toHaveBeenCalled();
+  });
+
+  it('submit sem nome exibe mensagem de validação do campo', async () => {
+    const user = userEvent.setup();
+    render(<EmployeeForm {...openProps} />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Ambulância/ }));
+    await user.click(screen.getByRole('button', { name: 'Criar' }));
+
+    expect(await screen.findByText('Nome é obrigatório')).toBeInTheDocument();
+    expect(mockStore.createEmployee).not.toHaveBeenCalled();
+  });
+
+  it('submit válido em modo criação chama createEmployee com payload correto', async () => {
+    const user = userEvent.setup();
+    render(<EmployeeForm {...openProps} />);
+
+    await user.type(screen.getByPlaceholderText('Nome completo'), 'Maria');
+    fireEvent.click(screen.getByRole('checkbox', { name: /Ambulância/ }));
+    await user.click(screen.getByRole('button', { name: 'Criar' }));
+
+    await waitFor(() => {
+      expect(mockStore.createEmployee).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Maria',
+          cargo: 'Motorista',
+          setores: ['Transporte Ambulância'],
+        })
+      );
+    });
+  });
+
+  it('submit válido em modo edição chama updateEmployee com id correto', async () => {
+    const user = userEvent.setup();
+    const employee = {
+      id: 5,
+      name: 'Carlos',
+      setores: ['Transporte Hemodiálise'],
+      vacations: [],
+      work_schedule: 'dom_sab',
+      color: '#6B7280',
+    };
+    render(<EmployeeForm {...openProps} employee={employee} />);
+
+    await user.click(screen.getByRole('button', { name: 'Salvar' }));
+
+    await waitFor(() => {
+      expect(mockStore.updateEmployee).toHaveBeenCalledWith(
+        5,
+        expect.objectContaining({ name: 'Carlos', cargo: 'Motorista' })
+      );
+    });
+  });
+
+  it('submit com ADM inclui apenas ADM no payload de setores', async () => {
+    const user = userEvent.setup();
+    render(<EmployeeForm {...openProps} />);
+
+    await user.type(screen.getByPlaceholderText('Nome completo'), 'Diretor');
+    fireEvent.click(screen.getByRole('checkbox', { name: /Administrativo/ }));
+    await user.click(screen.getByRole('button', { name: 'Criar' }));
+
+    await waitFor(() => {
+      expect(mockStore.createEmployee).toHaveBeenCalledWith(
+        expect.objectContaining({ setores: ['Transporte Administrativo'] })
+      );
+    });
+  });
+});

--- a/frontend/src/tests/setup.js
+++ b/frontend/src/tests/setup.js
@@ -1,1 +1,22 @@
 import '@testing-library/jest-dom';
+
+// Polyfills required by Radix UI in jsdom
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});


### PR DESCRIPTION
## Contexto

Segunda camada de cobertura de testes frontend. `useStore` já estava coberto (PR #25). Este PR adiciona testes de componentes para `ConfirmDialog` (compartilhado) e `EmployeeForm` (domínio employees), cobrindo a lógica de negócio mais relevante do frontend.

## setup.js — polyfills adicionados

Adicionados `ResizeObserver` e `window.matchMedia` ao setup de testes. Necessários porque Radix UI Dialog verifica essas APIs em jsdom. Sem eles, os testes falhariam com `ReferenceError`.

## ConfirmDialog.test.jsx — 11 testes

| Grupo | Casos |
|-------|-------|
| Renderização | title/description visíveis, botão Cancelar, confirmLabel padrão e customizado, open=false não renderiza |
| Variant | `danger` → `btn-danger`, `primary` → `btn-primary`, variant padrão = danger |
| Interações | onConfirm chamado 1x, onOpenChange(false) chamado, ordem onConfirm → onOpenChange |

O teste de ordem de chamada documenta um invariante importante: `onConfirm` é executado **antes** de fechar o dialog — se isso mudar, o teste quebra explicitamente.

## EmployeeForm.test.jsx — 23 testes

### Renderização (8 testes)
Modo criação vs edição (título, botão, seção férias), cargo/descanso fixos, open=false.

### toggleSetor — lógica ADM exclusivo (10 testes)
Esta é a regra de negócio central do componente (Regra 14):

| Cenário | Comportamento esperado |
|---------|----------------------|
| Selecionar Ambulância | Apenas Ambulância marcada |
| Ambulância + Hemodiálise | Ambas marcadas (multi-select válido) |
| Desselecionar Ambulância | Desmarca |
| ADM quando Ambulância marcada | ADM marcado, Ambulância e Hemodiálise desmarcadas |
| ADM quando nada marcado | ADM marcado |
| Desselecionar ADM | Tudo desmarcado |
| ADM selecionado → Ambulância/Hemodiálise disabled | disabled=true |
| ADM desselecionado → habilitação | disabled=false |
| Sem seleção → aviso visível | "Selecione pelo menos um setor" |
| Com seleção → aviso some | texto removido do DOM |

### Submit — validação e payload (5 testes)
- Sem setores → `addToast({ type: 'error' })`, `createEmployee` não chamado
- Sem nome → mensagem de validação react-hook-form, `createEmployee` não chamado
- Criação válida → `createEmployee` com `{ name, cargo: 'Motorista', setores }`
- Edição válida → `updateEmployee(id, payload)` com id correto
- ADM no payload → `setores: ['Transporte Administrativo']` (exclusivo)

## Estratégia de mock

`useStore` mockado com `vi.mock` + `useStore.mockReturnValue(mockStore)` no `beforeEach`.
Os mock functions permitem assertivas de chamada (foi chamado, com que args, quantas vezes).

## Logs de execução

```
Test Files  3 passed (3)
      Tests  64 passed (64)
   Duration  2.24s
```

## Taxa de sucesso

64/64 (100%)

> Nota: warnings `Missing Description for DialogContent` são avisos de acessibilidade do Radix UI — o `EmployeeForm` não define `Dialog.Description`. Não afetam os testes e são de responsabilidade do dev (não do Tester Senior).

---
*Tester Senior*