### PR TITLE
ci: script test monorepo + job frontend-tests no CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: ["master", "main"]
 
 jobs:
-  test:
+  backend-tests:
     name: Backend Tests
     runs-on: ubuntu-latest
 
@@ -31,3 +31,26 @@ jobs:
         working-directory: backend
         env:
           DB_PATH: ":memory:"
+
+  frontend-tests:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Run tests
+        run: npm test
+        working-directory: frontend

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "dev": "concurrently \"npm run dev --workspace=backend\" \"npm run dev --workspace=frontend\"",
+    "test": "npm test --workspace=backend && npm test --workspace=frontend",
     "install:all": "npm install && npm install --workspace=backend && npm install --workspace=frontend"
   },
   "devDependencies": {


### PR DESCRIPTION
## Contexto

Os PRs #25, #26 e #27 adicionaram infraestrutura de testes frontend (vitest + jsdom) e 64 testes novos. Porém o CI (`ci.yml`) só executava o job de backend, e a raiz do monorepo não tinha script `test`. Este PR corrige ambas as lacunas.

## Mudanças

### `package.json` (raiz)

Adicionado script:
```json
"test": "npm test --workspace=backend && npm test --workspace=frontend"
```

Usa npm workspaces nativamente — sem dependências novas. Executa backend primeiro, frontend segundo. Falha em qualquer um interrompe a execução.

### `.github/workflows/ci.yml`

**Antes**: 1 job `test` executando apenas backend.

**Depois**: 2 jobs paralelos:
- `backend-tests` — idêntico ao anterior (renomeado para clareza)
- `frontend-tests` — novo job com:
  - `actions/setup-node@v4` com cache `frontend/package-lock.json`
  - `npm ci` em `./frontend`
  - `npm test` em `./frontend` (vitest run)

Os jobs rodam em paralelo no GitHub Actions, sem dependência entre si — CI total mais rápido.

## Logs de execução (local)

**Backend** (116/116):
```
Test Files  9 passed (9)
      Tests  116 passed (116)
```

**Frontend** (64/64):
```
Test Files  3 passed (3)
      Tests  64 passed (64)
   Duration  2.24s
```

## Taxa de sucesso

180/180 (100%) — backend + frontend combinados

---
*DevOps Senior*