### PR TITLE
fix(generator): verifica descanso 24h em correctHours antes de converter folgas (issue #29)

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -710,6 +710,49 @@ function computeShiftEnd(date, shift) {
   return new Date(start.getTime() + shift.duration_hours * 60 * 60 * 1000);
 }
 
+/**
+ * Verifica se inserir `shift` na data de `targetEntry` respeita ≥24h de descanso
+ * em relação aos turnos adjacentes já existentes em `allEntries` (in-memory).
+ * Retorna true se é seguro converter; false caso contrário.
+ */
+function hasAdequateRest(allEntries, targetEntry, shift, shiftMap) {
+  const targetDate = targetEntry.date;
+
+  const workEntries = allEntries
+    .filter(e => !e.is_day_off && e.shift_type_id)
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  // Turno anterior
+  const prev = [...workEntries].reverse().find(e => e.date < targetDate);
+  if (prev) {
+    const prevShift = shiftMap[prev.shift_type_id];
+    if (prevShift) {
+      const prevEnd  = computeShiftEnd(prev.date, prevShift);
+      const newStart = computeShiftStart(targetDate, shift);
+      if (prevEnd && newStart) {
+        const restMs = newStart - prevEnd;
+        if (restMs < MIN_REST_HOURS * 3_600_000) return false;
+      }
+    }
+  }
+
+  // Turno seguinte
+  const next = workEntries.find(e => e.date > targetDate);
+  if (next) {
+    const nextShift = shiftMap[next.shift_type_id];
+    if (nextShift) {
+      const newEnd    = computeShiftEnd(targetDate, shift);
+      const nextStart = computeShiftStart(next.date, nextShift);
+      if (newEnd && nextStart) {
+        const restMs = nextStart - newEnd;
+        if (restMs < MIN_REST_HOURS * 3_600_000) return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 export function correctHours(entries, shiftTypes, shiftMap, currentHours, target, preferredShift = null, lockedOffDates = new Set()) {
   const diff = currentHours - target;
   if (Math.abs(diff) <= 6) return entries;
@@ -740,6 +783,7 @@ export function correctHours(entries, shiftTypes, shiftMap, currentHours, target
     for (const entry of offEntries) {
       if (deficit <= 0) break;
       if (lockedOffDates.has(entry.date)) continue;
+      if (!hasAdequateRest(entries, entry, shiftToAdd, shiftMap)) continue;
       entry.is_day_off = 0;
       entry.shift_type_id = shiftToAdd.id;
       deficit -= shiftToAdd.duration_hours;

--- a/backend/src/tests/scheduleGenerator.unit.test.js
+++ b/backend/src/tests/scheduleGenerator.unit.test.js
@@ -46,4 +46,32 @@ describe('correctHours', () => {
     const hours = result.filter(e => !e.is_day_off).length * 12;
     expect(hours).toBeGreaterThan(120);
   });
+
+  it('não converte folga que viola 24h de descanso após turno noturno', () => {
+    const nocturno = { id: 1, name: 'Noturno', duration_hours: 12, start_time: '19:00' };
+    const localShiftTypes = [nocturno];
+    const localShiftMap   = { 1: nocturno };
+
+    // Sex Noturno (19:00 → Sáb 07:00); Sáb folga = apenas 12h rest → deve ser ignorada
+    // Seg e Ter folgas (>24h de descanso) → devem ser convertidas para cobrir o déficit
+    const entries = [
+      { date: '2025-01-06', is_day_off: 0, shift_type_id: 1 }, // Seg
+      { date: '2025-01-07', is_day_off: 0, shift_type_id: 1 }, // Ter
+      { date: '2025-01-08', is_day_off: 0, shift_type_id: 1 }, // Qua
+      { date: '2025-01-09', is_day_off: 0, shift_type_id: 1 }, // Qui
+      { date: '2025-01-10', is_day_off: 0, shift_type_id: 1 }, // Sex (termina Sáb 07:00)
+      { date: '2025-01-11', is_day_off: 1, shift_type_id: null }, // Sáb (12h rest → ignorar)
+      { date: '2025-01-13', is_day_off: 1, shift_type_id: null }, // Seg folga boa
+      { date: '2025-01-14', is_day_off: 1, shift_type_id: null }, // Ter folga boa
+    ];
+    // currentHours = 5*12 = 60, target = 84 → deficit = 24h (precisa converter 2 folgas)
+
+    correctHours(entries, localShiftTypes, localShiftMap, 60, 84, nocturno);
+
+    const sab = entries.find(e => e.date === '2025-01-11');
+    expect(sab.is_day_off).toBe(1); // NÃO convertida — violaria 24h rest
+
+    const converted = entries.filter(e => !e.is_day_off);
+    expect(converted.length).toBeGreaterThan(5); // folgas boas foram convertidas
+  });
 });


### PR DESCRIPTION
## Descrição

Adiciona o helper puro `hasAdequateRest` em `scheduleGenerator.js` e o usa no loop de déficit de `correctHours` para impedir a conversão de folgas que violariam MIN_REST_HOURS (24h).

## Problema

`correctHours` iterava `offEntries` e convertia folgas em turnos de trabalho sem verificar descanso mínimo de 24h entre turnos adjacentes, podendo gerar, por exemplo:

- Sex Noturno (19:00 → Sáb 07:00)
- Sáb convertido para Noturno (19:00) → apenas 12h de descanso → **viola Regra 4**

## Solução

### Novo helper `hasAdequateRest(allEntries, targetEntry, shift, shiftMap)`

- Opera exclusivamente in-memory (não acessa DB)
- Verifica o turno anterior e o turno seguinte à entrada candidata
- Usa `computeShiftStart` / `computeShiftEnd` existentes — retornam `null` se `start_time` ausente, preservando comportamento dos testes sem `start_time`
- Considera conversões já feitas na mesma passagem (opera sobre `entries` mutado in-place)

### Chamada no loop de déficit

```js
if (!hasAdequateRest(entries, entry, shiftToAdd, shiftMap)) continue;
```

## Testes

- **117/117** testes backend passando (+1 novo)
- Novo teste: `'não converte folga que viola 24h de descanso após turno noturno'`
  - Sáb (12h rest após Sex Noturno) → mantido como folga ✓
  - Folgas com descanso adequado → convertidas normalmente ✓
- Testes existentes de `correctHours` sem `start_time` → comportamento inalterado ✓

## Arquivos alterados

- `backend/src/services/scheduleGenerator.js` — +44 linhas (helper + guard)
- `backend/src/tests/scheduleGenerator.unit.test.js` — +28 linhas (novo teste)

Closes #29