### PR TITLE
feat(generator): enforceDailyCoverage — garante 1 motorista por dia (issue #33)

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -100,7 +100,7 @@ export async function generateSchedule({ month, year, overwriteLocked = false })
   if (noturnoShift) {
     enforceNocturnalCoverage(db, employees, employeeSectorsMap, dates, noturnoShift, warnings);
   }
-  checkDailyDriverCoverage(db, dates, warnings);
+  enforceDailyCoverage(db, employees, employeeSectorsMap, shiftTypes, dates, warnings);
 
   // Log generation
   db.prepare(
@@ -658,9 +658,36 @@ function enforceNocturnalCoverage(db, employees, employeeSectorsMap, dates, notu
 }
 
 /**
- * Rule 19: Todo dia deve ter pelo menos 1 motorista escalado.
+ * Rule 19 (enforcement): Garante que todo dia do mês tem pelo menos 1 motorista.
+ * @exported para testes unitários
+ * Passa 1: converte folga de candidato elegível respeitando restrições de descanso.
+ * Passo 2 (fallback): força a conversão ignorando MIN_REST_HOURS e dias consecutivos.
+ * Respeita work_schedule=seg_sex mesmo no passo forçado.
+ * Emite warning quando a cobertura foi forçada ou quando é impossível.
  */
-function checkDailyDriverCoverage(db, dates, warnings) {
+export function enforceDailyCoverage(db, employees, employeeSectorsMap, shiftTypes, dates, warnings) {
+  const defaultShift =
+    shiftTypes.find((s) => s.duration_hours === DEFAULT_SHIFT_HOURS) || shiftTypes[0];
+
+  // Cache preferred shift por employee_id
+  const preferredShiftCache = {};
+  const getShiftForEmp = (emp) => {
+    if (preferredShiftCache[emp.id] !== undefined) return preferredShiftCache[emp.id];
+    const rules = db
+      .prepare('SELECT preferred_shift_id FROM employee_rest_rules WHERE employee_id = ?')
+      .get(emp.id);
+    if (rules?.preferred_shift_id) {
+      const s = shiftTypes.find((sh) => sh.id === rules.preferred_shift_id);
+      if (s) { preferredShiftCache[emp.id] = s; return s; }
+    }
+    const isAdm = (employeeSectorsMap[emp.id] || []).includes(SETOR_ADM);
+    const fallback = isAdm
+      ? (shiftTypes.find((s) => s.name === SHIFT_ADM_NAME) || defaultShift)
+      : defaultShift;
+    preferredShiftCache[emp.id] = fallback;
+    return fallback;
+  };
+
   for (const date of dates) {
     const row = db
       .prepare(
@@ -669,12 +696,84 @@ function checkDailyDriverCoverage(db, dates, warnings) {
            AND employee_id IN (SELECT id FROM employees WHERE active = 1)`
       )
       .get(date);
-    if (row.c === 0) {
+    if (row.c > 0) continue;
+
+    const dow = new Date(date + 'T12:00:00').getDay();
+
+    // Candidatos: folgas não-bloqueadas e não-férias neste dia
+    const folgas = db
+      .prepare(
+        `SELECT se.id, se.employee_id FROM schedule_entries se
+         WHERE se.date = ? AND se.is_day_off = 1 AND se.is_locked = 0
+           AND (se.notes IS NULL OR se.notes != 'Férias')
+           AND se.employee_id IN (SELECT id FROM employees WHERE active = 1)`
+      )
+      .all(date);
+
+    if (folgas.length === 0) {
+      warnings.push({ type: 'sem_motorista', date, message: `${date}: nenhum motorista escalado` });
+      continue;
+    }
+
+    // Ordena candidatos por mais dias desde o último trabalho (mais descansado primeiro)
+    const candidates = folgas
+      .map((f) => {
+        const emp = employees.find((e) => e.id === f.employee_id);
+        if (!emp) return null;
+        const lastWork = db
+          .prepare(
+            `SELECT date FROM schedule_entries
+             WHERE employee_id = ? AND date < ? AND is_day_off = 0
+             ORDER BY date DESC LIMIT 1`
+          )
+          .get(emp.id, date);
+        const daysSince = lastWork
+          ? Math.round(
+              (new Date(date + 'T12:00:00Z') - new Date(lastWork.date + 'T12:00:00Z')) /
+                86_400_000
+            )
+          : 999;
+        return { folgaId: f.id, emp, daysSince };
+      })
+      .filter(Boolean)
+      .sort((a, b) => b.daysSince - a.daysSince);
+
+    const startDate = dates[0];
+    const endDate   = dates[dates.length - 1];
+
+    // Passo 1: com restrições de descanso e cap de horas
+    let assigned = false;
+    for (const { folgaId, emp } of candidates) {
+      if (emp.work_schedule === 'seg_sex' && (dow === 0 || dow === 6)) continue;
+      if (getEmployeeHours(db, emp.id, startDate, endDate) >= COVERAGE_HOURS_CAP) continue;
+      const shift = getShiftForEmp(emp);
+      if (!canAssignShift(db, emp.id, date, shift)) continue;
+      db.prepare('UPDATE schedule_entries SET is_day_off = 0, shift_type_id = ? WHERE id = ?')
+        .run(shift.id, folgaId);
+      assigned = true;
+      break;
+    }
+    if (assigned) continue;
+
+    // Passo 2: forçado — ignora restrições de descanso e consecutivos, mantém cap de horas
+    let forced = false;
+    for (const { folgaId, emp } of candidates) {
+      if (emp.work_schedule === 'seg_sex' && (dow === 0 || dow === 6)) continue;
+      if (getEmployeeHours(db, emp.id, startDate, endDate) >= COVERAGE_HOURS_CAP) continue;
+      const shift = getShiftForEmp(emp);
+      db.prepare('UPDATE schedule_entries SET is_day_off = 0, shift_type_id = ? WHERE id = ?')
+        .run(shift.id, folgaId);
       warnings.push({
-        type: 'sem_motorista',
+        type: 'sem_motorista_forcado',
         date,
-        message: `${date}: nenhum motorista escalado`,
+        employee: emp.name,
+        message: `${date}: cobertura diária forçada para ${emp.name} (restrições de descanso ignoradas)`,
       });
+      forced = true;
+      break;
+    }
+    if (!forced) {
+      warnings.push({ type: 'sem_motorista', date, message: `${date}: nenhum motorista escalado` });
     }
   }
 }

--- a/backend/src/tests/scheduleGenerator.unit.test.js
+++ b/backend/src/tests/scheduleGenerator.unit.test.js
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { isValidEmendado, correctHours } from '../services/scheduleGenerator.js';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { isValidEmendado, correctHours, enforceDailyCoverage } from '../services/scheduleGenerator.js';
+import { freshDb, createEmployee } from './helpers.js';
 
 describe('isValidEmendado', () => {
   it('permite Tarde → Noturno', () => expect(isValidEmendado('Tarde', 'Noturno')).toBe(true));
@@ -105,5 +106,121 @@ describe('correctHours', () => {
 
     const workDays = entries.filter(e => !e.is_day_off);
     expect(workDays.length).toBeGreaterThan(7); // folgas boas convertidas
+  });
+});
+
+// ─── enforceDailyCoverage ─────────────────────────────────────────────────────
+
+describe('enforceDailyCoverage', () => {
+  let db;
+
+  beforeEach(() => { db = freshDb(); });
+
+  // Helper: insere entrada de escala diretamente no DB
+  function insertEntry(db, { employee_id, date, is_day_off, shift_type_id = null, is_locked = 0, notes = null }) {
+    db.prepare(
+      'INSERT INTO schedule_entries (employee_id, date, is_day_off, shift_type_id, is_locked, notes) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(employee_id, date, is_day_off, shift_type_id, is_locked, notes);
+  }
+
+  // Helper: retorna entry do DB para (employee_id, date)
+  function getEntry(db, employee_id, date) {
+    return db.prepare('SELECT * FROM schedule_entries WHERE employee_id = ? AND date = ?').get(employee_id, date);
+  }
+
+  it('converte folga em turno quando dia não tem motorista (passo 1 — sem forçar)', () => {
+    // Sem entradas adjacentes → prevEntry e nextEntry são null → canAssignShift retorna true
+    const emp = createEmployee(db, { name: 'Ana', setor: 'Transporte Ambulância' });
+    insertEntry(db, { employee_id: emp.id, date: '2025-01-05', is_day_off: 1, shift_type_id: null });
+
+    const employees = [{ ...emp, setores: ['Transporte Ambulância'] }];
+    const sectorMap = { [emp.id]: ['Transporte Ambulância'] };
+    const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
+    const warnings = [];
+
+    enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-05'], warnings);
+
+    const entry = getEntry(db, emp.id, '2025-01-05');
+    expect(entry.is_day_off).toBe(0);
+    expect(entry.shift_type_id).toBeTruthy();
+    expect(warnings).toHaveLength(0); // cobertura sem force: sem warning
+  });
+
+  it('emite warning sem_motorista_forcado quando único candidato viola restrições de descanso', () => {
+    // Turnos com start_time para que canAssignShift rejeite por descanso insuficiente
+    // Funcionário com poucas horas (<160h) para não ser bloqueado pelo cap
+    const noturno = db.prepare("SELECT * FROM shift_types WHERE name = 'Noturno'").get();
+    const emp = createEmployee(db, { name: 'Bruno', setor: 'Transporte Ambulância' });
+
+    // Apenas 1 dia de trabalho anterior (12h < 160h cap) + folga adjacente
+    // Jan 4 noturno (termina Jan 5 07:00); Jan 5 folga — 12h rest → canAssign rejeita (< 24h)
+    insertEntry(db, { employee_id: emp.id, date: '2025-01-04', is_day_off: 0, shift_type_id: noturno.id });
+    insertEntry(db, { employee_id: emp.id, date: '2025-01-05', is_day_off: 1, shift_type_id: null });
+
+    const employees = [{ ...emp, setores: ['Transporte Ambulância'] }];
+    const sectorMap = { [emp.id]: ['Transporte Ambulância'] };
+    const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
+    const warnings = [];
+
+    enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-05'], warnings);
+
+    // Deve ter sido forçado — warning emitido
+    expect(warnings.some(w => w.type === 'sem_motorista_forcado')).toBe(true);
+    // E o dia deve ter sido coberto mesmo assim
+    const entry = getEntry(db, emp.id, '2025-01-05');
+    expect(entry.is_day_off).toBe(0);
+  });
+
+  it('emite warning sem_motorista quando não há nenhuma folga disponível no dia', () => {
+    const emp = createEmployee(db, { name: 'Carlos', setor: 'Transporte Ambulância' });
+    // Nenhuma entry no DB para Jan 10 — folgas.length = 0
+    const employees = [{ ...emp, setores: ['Transporte Ambulância'] }];
+    const sectorMap = { [emp.id]: ['Transporte Ambulância'] };
+    const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
+    const warnings = [];
+
+    enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-10'], warnings);
+
+    expect(warnings.some(w => w.type === 'sem_motorista' && w.date === '2025-01-10')).toBe(true);
+  });
+
+  it('não força funcionário seg_sex a trabalhar no Domingo', () => {
+    const noturno = db.prepare("SELECT * FROM shift_types WHERE name = 'Noturno'").get();
+    // seg_sex employee com folga no Domingo (Jan 5, 2025 = Domingo)
+    const emp = db.prepare("INSERT INTO employees (name, cargo, work_schedule) VALUES ('Diana', 'Motorista', 'seg_sex')").run();
+    const empId = emp.lastInsertRowid;
+    db.prepare('INSERT INTO employee_sectors (employee_id, setor) VALUES (?, ?)').run(empId, 'Transporte Ambulância');
+    db.prepare('INSERT INTO employee_rest_rules (employee_id, min_rest_hours) VALUES (?, 24)').run(empId);
+    insertEntry(db, { employee_id: empId, date: '2025-01-05', is_day_off: 1, shift_type_id: null });
+
+    const empObj = db.prepare('SELECT * FROM employees WHERE id = ?').get(empId);
+    const employees = [{ ...empObj, setores: ['Transporte Ambulância'] }];
+    const sectorMap = { [empId]: ['Transporte Ambulância'] };
+    const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
+    const warnings = [];
+
+    // Jan 5, 2025 = Domingo; seg_sex não pode ser forçado
+    enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-05'], warnings);
+
+    const entry = getEntry(db, empId, '2025-01-05');
+    expect(entry.is_day_off).toBe(1); // não convertido
+    expect(warnings.some(w => w.type === 'sem_motorista')).toBe(true);
+  });
+
+  it('não toca dias que já têm motorista escalado', () => {
+    const noturno = db.prepare("SELECT * FROM shift_types WHERE name = 'Noturno'").get();
+    const emp = createEmployee(db, { name: 'Eva', setor: 'Transporte Ambulância' });
+    insertEntry(db, { employee_id: emp.id, date: '2025-01-15', is_day_off: 0, shift_type_id: noturno.id });
+
+    const employees = [{ ...emp, setores: ['Transporte Ambulância'] }];
+    const sectorMap = { [emp.id]: ['Transporte Ambulância'] };
+    const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
+    const warnings = [];
+
+    enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-15'], warnings);
+
+    expect(warnings).toHaveLength(0);
+    const entry = getEntry(db, emp.id, '2025-01-15');
+    expect(entry.is_day_off).toBe(0); // permanece trabalho
   });
 });


### PR DESCRIPTION
## Problema

A escala gerada podia produzir dias inteiros sem nenhum motorista alocado. A Regra 19 emitia um warning mas não corrigia o problema. Domingos e outros dias de folga geral ficavam sem cobertura.

## Solução

### `enforceDailyCoverage` (substitui `checkDailyDriverCoverage`)

Executa após `enforceDiurnoCoverage` e `enforceNocturnalCoverage`. Para cada dia sem motorista:

**Passo 1 — com restrições:**
- Candidatos: funcionários com folga não-bloqueada, abaixo do cap de 160h
- Ordenados por dias desde o último trabalho (mais descansado primeiro)
- Rejeita se `canAssignShift` falha (24h rest ou emendado)

**Passo 2 — forçado (fallback):**
- Ignora `MIN_REST_HOURS` e dias consecutivos (conforme decisão de produto)
- Mantém o cap de 160h (não sobrecarrega quem já atingiu o alvo)
- Emite warning `sem_motorista_forcado` com nome do funcionário

**Sem candidato elegível:** emite warning `sem_motorista` (equipe insuficiente).

## Decisões de implementação

| Questão | Decisão |
|---|---|
| Respeita seg_sex em Sáb/Dom? | **Sim** — em ambas as passagens |
| Respeita cap de 160h no passo forçado? | **Sim** — o issue especifica ignorar rest/consecutivos, não o cap de horas |
| Warning quando forçado? | **Sim** — `sem_motorista_forcado` para rastreabilidade |

## Plano de teste

| Cenário | Expectativa |
|---|---|
| Dia sem motorista, candidato elegível | Passo 1 converte, sem warning |
| Candidato viola 24h rest, abaixo do cap | Passo 2 força, warning emitido |
| Nenhuma folga disponível | Warning `sem_motorista` |
| seg_sex em Domingo | Não forçado, warning emitido |
| Dia já com motorista | Não tocado |

## Testes

- **5 novos casos unitários** para `enforceDailyCoverage`
- **123/123 backend passando** (sem regressoes)

```
Test Files  7 passed (7)
      Tests  123 passed (123)
```

Closes #33

🤖 Desenvolvedor Pleno