### PR TITLE
fix(generator): passo 3 em enforceDailyCoverage — cobre fins de semana com seg_sex (issue #36)

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -660,10 +660,11 @@ function enforceNocturnalCoverage(db, employees, employeeSectorsMap, dates, notu
 /**
  * Rule 19 (enforcement): Garante que todo dia do mês tem pelo menos 1 motorista.
  * @exported para testes unitários
- * Passa 1: converte folga de candidato elegível respeitando restrições de descanso.
- * Passo 2 (fallback): força a conversão ignorando MIN_REST_HOURS e dias consecutivos.
- * Respeita work_schedule=seg_sex mesmo no passo forçado.
- * Emite warning quando a cobertura foi forçada ou quando é impossível.
+ * Passo 1: converte folga respeitando restrições de descanso e work_schedule=seg_sex.
+ * Passo 2 (fallback): ignora MIN_REST_HOURS e consecutivos; ainda respeita seg_sex.
+ * Passo 3 (emergência): força até candidatos seg_sex em Sáb/Dom quando não há outro.
+ *   Emite warning sem_motorista_forcado_seg_sex para rastreabilidade.
+ * Emite sem_motorista apenas quando não há nenhuma folga disponível.
  */
 export function enforceDailyCoverage(db, employees, employeeSectorsMap, shiftTypes, dates, warnings) {
   const defaultShift =
@@ -699,6 +700,7 @@ export function enforceDailyCoverage(db, employees, employeeSectorsMap, shiftTyp
     if (row.c > 0) continue;
 
     const dow = new Date(date + 'T12:00:00').getDay();
+    const isWeekend = dow === 0 || dow === 6;
 
     // Candidatos: folgas não-bloqueadas e não-férias neste dia
     const folgas = db
@@ -741,10 +743,10 @@ export function enforceDailyCoverage(db, employees, employeeSectorsMap, shiftTyp
     const startDate = dates[0];
     const endDate   = dates[dates.length - 1];
 
-    // Passo 1: com restrições de descanso e cap de horas
+    // Passo 1: com restrições de descanso e cap de horas (respeita seg_sex)
     let assigned = false;
     for (const { folgaId, emp } of candidates) {
-      if (emp.work_schedule === 'seg_sex' && (dow === 0 || dow === 6)) continue;
+      if (emp.work_schedule === 'seg_sex' && isWeekend) continue;
       if (getEmployeeHours(db, emp.id, startDate, endDate) >= COVERAGE_HOURS_CAP) continue;
       const shift = getShiftForEmp(emp);
       if (!canAssignShift(db, emp.id, date, shift)) continue;
@@ -755,10 +757,10 @@ export function enforceDailyCoverage(db, employees, employeeSectorsMap, shiftTyp
     }
     if (assigned) continue;
 
-    // Passo 2: forçado — ignora restrições de descanso e consecutivos, mantém cap de horas
+    // Passo 2: forçado — ignora restrições de descanso e consecutivos (respeita seg_sex e cap)
     let forced = false;
     for (const { folgaId, emp } of candidates) {
-      if (emp.work_schedule === 'seg_sex' && (dow === 0 || dow === 6)) continue;
+      if (emp.work_schedule === 'seg_sex' && isWeekend) continue;
       if (getEmployeeHours(db, emp.id, startDate, endDate) >= COVERAGE_HOURS_CAP) continue;
       const shift = getShiftForEmp(emp);
       db.prepare('UPDATE schedule_entries SET is_day_off = 0, shift_type_id = ? WHERE id = ?')
@@ -768,6 +770,23 @@ export function enforceDailyCoverage(db, employees, employeeSectorsMap, shiftTyp
         date,
         employee: emp.name,
         message: `${date}: cobertura diária forçada para ${emp.name} (restrições de descanso ignoradas)`,
+      });
+      forced = true;
+      break;
+    }
+    if (forced) continue;
+
+    // Passo 3 (emergência): força candidato seg_sex em Sáb/Dom — equipe insuficiente de dom_sab
+    for (const { folgaId, emp } of candidates) {
+      if (getEmployeeHours(db, emp.id, startDate, endDate) >= COVERAGE_HOURS_CAP) continue;
+      const shift = getShiftForEmp(emp);
+      db.prepare('UPDATE schedule_entries SET is_day_off = 0, shift_type_id = ? WHERE id = ?')
+        .run(shift.id, folgaId);
+      warnings.push({
+        type: 'sem_motorista_forcado_seg_sex',
+        date,
+        employee: emp.name,
+        message: `${date}: cobertura de emergência para ${emp.name} (seg_sex forçado em fim de semana — equipe insuficiente)`,
       });
       forced = true;
       break;

--- a/backend/src/tests/scheduleGenerator.unit.test.js
+++ b/backend/src/tests/scheduleGenerator.unit.test.js
@@ -184,9 +184,9 @@ describe('enforceDailyCoverage', () => {
     expect(warnings.some(w => w.type === 'sem_motorista' && w.date === '2025-01-10')).toBe(true);
   });
 
-  it('não força funcionário seg_sex a trabalhar no Domingo', () => {
-    const noturno = db.prepare("SELECT * FROM shift_types WHERE name = 'Noturno'").get();
-    // seg_sex employee com folga no Domingo (Jan 5, 2025 = Domingo)
+  it('força funcionário seg_sex no Domingo via passo 3 (emergência) quando não há dom_sab disponível', () => {
+    // Jan 5, 2025 = Domingo; único candidato é seg_sex
+    // Passo 1 e 2 ignoram seg_sex em fins de semana; passo 3 força com warning distinto
     const emp = db.prepare("INSERT INTO employees (name, cargo, work_schedule) VALUES ('Diana', 'Motorista', 'seg_sex')").run();
     const empId = emp.lastInsertRowid;
     db.prepare('INSERT INTO employee_sectors (employee_id, setor) VALUES (?, ?)').run(empId, 'Transporte Ambulância');
@@ -199,12 +199,39 @@ describe('enforceDailyCoverage', () => {
     const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
     const warnings = [];
 
-    // Jan 5, 2025 = Domingo; seg_sex não pode ser forçado
     enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-05'], warnings);
 
+    // Passo 3: cobertura garantida mesmo sendo seg_sex
     const entry = getEntry(db, empId, '2025-01-05');
-    expect(entry.is_day_off).toBe(1); // não convertido
-    expect(warnings.some(w => w.type === 'sem_motorista')).toBe(true);
+    expect(entry.is_day_off).toBe(0); // convertido pelo passo 3
+    expect(warnings.some(w => w.type === 'sem_motorista_forcado_seg_sex')).toBe(true);
+    expect(warnings.some(w => w.type === 'sem_motorista')).toBe(false); // dia foi coberto
+  });
+
+  it('passo 3 não é acionado quando há dom_sab disponível no Sábado', () => {
+    // Sáb Jan 4, 2025: 1 seg_sex (passo 1/2 o ignora) + 1 dom_sab (passo 2 o pega)
+    const empSegSex = db.prepare("INSERT INTO employees (name, cargo, work_schedule) VALUES ('Eduardo', 'Motorista', 'seg_sex')").run();
+    const empDomSab = db.prepare("INSERT INTO employees (name, cargo, work_schedule) VALUES ('Fernanda', 'Motorista', 'dom_sab')").run();
+    for (const id of [empSegSex.lastInsertRowid, empDomSab.lastInsertRowid]) {
+      db.prepare('INSERT INTO employee_sectors (employee_id, setor) VALUES (?, ?)').run(id, 'Transporte Ambulância');
+      db.prepare('INSERT INTO employee_rest_rules (employee_id, min_rest_hours) VALUES (?, 24)').run(id);
+      insertEntry(db, { employee_id: id, date: '2025-01-04', is_day_off: 1, shift_type_id: null });
+    }
+
+    const allEmps = db.prepare('SELECT * FROM employees WHERE active = 1').all()
+      .map(e => ({ ...e, setores: ['Transporte Ambulância'] }));
+    const sectorMap = Object.fromEntries(allEmps.map(e => [e.id, ['Transporte Ambulância']]));
+    const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
+    const warnings = [];
+
+    enforceDailyCoverage(db, allEmps, sectorMap, shiftTypes, ['2025-01-04'], warnings);
+
+    // dom_sab (Fernanda) deve ter sido escalada; seg_sex (Eduardo) não tocado
+    const entrySegSex = getEntry(db, empSegSex.lastInsertRowid, '2025-01-04');
+    const entryDomSab = getEntry(db, empDomSab.lastInsertRowid, '2025-01-04');
+    expect(entryDomSab.is_day_off).toBe(0); // Fernanda trabalha
+    expect(entrySegSex.is_day_off).toBe(1); // Eduardo preservado
+    expect(warnings.some(w => w.type === 'sem_motorista_forcado_seg_sex')).toBe(false);
   });
 
   it('não toca dias que já têm motorista escalado', () => {


### PR DESCRIPTION
## Problema

Ao gerar a escala de fevereiro/2026, os sábados (dias 7, 14, 21, 28) ficavam sem nenhum motorista. Quando todos os funcionários têm `work_schedule = seg_sex`, os passos 1 e 2 de `enforceDailyCoverage` ignoram esses candidatos em Sáb/Dom, resultando em `sem_motorista` — violando a Regra 19.

## Solução

### Passo 3 (emergência) adicionado a `enforceDailyCoverage`

Após passo 1 (com restrições) e passo 2 (forçado, ainda respeita seg_sex) falharem:

- **Passo 3**: itera os mesmos candidatos sem o guard `seg_sex && isWeekend`
- Mantém o cap de 160h (`COVERAGE_HOURS_CAP`)
- Emite warning `sem_motorista_forcado_seg_sex` com nome do funcionário e mensagem explicativa
- Só é acionado quando não há nenhum candidato `dom_sab` disponível

### Hierarquia dos passos

| Passo | Respeita seg_sex | Respeita rest/consecutivos | Respeita cap 160h |
|---|---|---|---|
| 1 | Sim | Sim (via canAssignShift) | Sim |
| 2 | Sim | Não | Sim |
| 3 (novo) | **Não** | Não | Sim |

## Decisão de implementação

| Questão | Decisão |
|---|---|
| Por que passo 3 separado de passo 2? | Para não degradar dom_sab — eles têm prioridade nos passos 1 e 2 |
| Warning distinto? | Sim — `sem_motorista_forcado_seg_sex` diferencia emergência de fim de semana de violação de descanso |
| Cap de horas mantido? | Sim — consistente com todos os outros passos de enforcement |

## Testes

| Cenário | Expectativa |
|---|---|
| Único candidato é seg_sex em Domingo | Passo 3 força, warning `sem_motorista_forcado_seg_sex` emitido |
| Há dom_sab disponível no Sábado | Passo 2 escala dom_sab; seg_sex não é tocado; sem warning de emergência |

- **124/124 backend passando** (sem regressões)

```
Test Files  7 passed (7)
      Tests  124 passed (124)
```

Closes #36

🤖 Desenvolvedor Pleno