### PR TITLE
feat(generator): cobertura mínima de 2 motoristas/dia (issue #42)

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -11,6 +11,7 @@ export const EMENDADO_PAIRS = [
 const MIN_REST_HOURS           = 24;  // Fixo, não editável (regra 10)
 const MAX_CONSECUTIVE_HOURS    = 18;  // Regra: máximo 18h consecutivas
 const MAX_CONSECUTIVE_WORK_DAYS = 6;  // Regra: máximo 6 dias de trabalho consecutivos
+const MIN_DAILY_COVERAGE        = 2;  // Regra 42: mínimo 2 motoristas por dia (issue #42)
 const TARGET_HOURS          = 160;
 const DEFAULT_SHIFT_HOURS   = 12;   // Padrão esperado: plantão de 12 horas
 const SETOR_ADM             = 'Transporte Administrativo';
@@ -658,13 +659,16 @@ function enforceNocturnalCoverage(db, employees, employeeSectorsMap, dates, notu
 }
 
 /**
- * Rule 19 (enforcement): Garante que todo dia do mês tem pelo menos 1 motorista.
+ * Rule 19/42 (enforcement): Garante cobertura mínima de MIN_DAILY_COVERAGE motoristas por dia.
  * @exported para testes unitários
+ * Loop por iteração até filled === MIN_DAILY_COVERAGE, re-buscando folgas a cada volta.
  * Passo 1: converte folga respeitando restrições de descanso e work_schedule=seg_sex.
  * Passo 2 (fallback): ignora MIN_REST_HOURS e consecutivos; ainda respeita seg_sex.
+ *   Emite sem_motorista_forcado (1º) ou segundo_motorista_forcado (2º+).
  * Passo 3 (emergência): força até candidatos seg_sex em Sáb/Dom quando não há outro.
  *   Emite warning sem_motorista_forcado_seg_sex para rastreabilidade.
- * Emite sem_motorista apenas quando não há nenhuma folga disponível.
+ * Emite sem_motorista (filled=0) ou cobertura_minima_insuficiente (filled>0 mas <MIN)
+ *   quando não há candidatos disponíveis.
  */
 export function enforceDailyCoverage(db, employees, employeeSectorsMap, shiftTypes, dates, warnings) {
   const defaultShift =
@@ -690,109 +694,136 @@ export function enforceDailyCoverage(db, employees, employeeSectorsMap, shiftTyp
   };
 
   for (const date of dates) {
-    const row = db
+    const initialCount = db
       .prepare(
         `SELECT COUNT(*) as c FROM schedule_entries
          WHERE date = ? AND is_day_off = 0
            AND employee_id IN (SELECT id FROM employees WHERE active = 1)`
       )
-      .get(date);
-    if (row.c > 0) continue;
+      .get(date).c;
+    if (initialCount >= MIN_DAILY_COVERAGE) continue;
 
     const dow = new Date(date + 'T12:00:00').getDay();
     const isWeekend = dow === 0 || dow === 6;
-
-    // Candidatos: folgas não-bloqueadas e não-férias neste dia
-    const folgas = db
-      .prepare(
-        `SELECT se.id, se.employee_id FROM schedule_entries se
-         WHERE se.date = ? AND se.is_day_off = 1 AND se.is_locked = 0
-           AND (se.notes IS NULL OR se.notes != 'Férias')
-           AND se.employee_id IN (SELECT id FROM employees WHERE active = 1)`
-      )
-      .all(date);
-
-    if (folgas.length === 0) {
-      warnings.push({ type: 'sem_motorista', date, message: `${date}: nenhum motorista escalado` });
-      continue;
-    }
-
-    // Ordena candidatos por mais dias desde o último trabalho (mais descansado primeiro)
-    const candidates = folgas
-      .map((f) => {
-        const emp = employees.find((e) => e.id === f.employee_id);
-        if (!emp) return null;
-        const lastWork = db
-          .prepare(
-            `SELECT date FROM schedule_entries
-             WHERE employee_id = ? AND date < ? AND is_day_off = 0
-             ORDER BY date DESC LIMIT 1`
-          )
-          .get(emp.id, date);
-        const daysSince = lastWork
-          ? Math.round(
-              (new Date(date + 'T12:00:00Z') - new Date(lastWork.date + 'T12:00:00Z')) /
-                86_400_000
-            )
-          : 999;
-        return { folgaId: f.id, emp, daysSince };
-      })
-      .filter(Boolean)
-      .sort((a, b) => b.daysSince - a.daysSince);
-
     const startDate = dates[0];
     const endDate   = dates[dates.length - 1];
 
-    // Passo 1: com restrições de descanso e cap de horas (respeita seg_sex)
-    let assigned = false;
-    for (const { folgaId, emp } of candidates) {
-      if (emp.work_schedule === 'seg_sex' && isWeekend) continue;
-      if (getEmployeeHours(db, emp.id, startDate, endDate) >= COVERAGE_HOURS_CAP) continue;
-      const shift = getShiftForEmp(emp);
-      if (!canAssignShift(db, emp.id, date, shift)) continue;
-      db.prepare('UPDATE schedule_entries SET is_day_off = 0, shift_type_id = ? WHERE id = ?')
-        .run(shift.id, folgaId);
-      assigned = true;
-      break;
-    }
-    if (assigned) continue;
+    let filled = initialCount;
 
-    // Passo 2: forçado — ignora restrições de descanso e consecutivos (respeita seg_sex e cap)
-    let forced = false;
-    for (const { folgaId, emp } of candidates) {
-      if (emp.work_schedule === 'seg_sex' && isWeekend) continue;
-      if (getEmployeeHours(db, emp.id, startDate, endDate) >= COVERAGE_HOURS_CAP) continue;
-      const shift = getShiftForEmp(emp);
-      db.prepare('UPDATE schedule_entries SET is_day_off = 0, shift_type_id = ? WHERE id = ?')
-        .run(shift.id, folgaId);
-      warnings.push({
-        type: 'sem_motorista_forcado',
-        date,
-        employee: emp.name,
-        message: `${date}: cobertura diária forçada para ${emp.name} (restrições de descanso ignoradas)`,
-      });
-      forced = true;
-      break;
-    }
-    if (forced) continue;
+    while (filled < MIN_DAILY_COVERAGE) {
+      // Re-busca folgas a cada iteração — candidatos mudam após cada atribuição
+      const folgas = db
+        .prepare(
+          `SELECT se.id, se.employee_id FROM schedule_entries se
+           WHERE se.date = ? AND se.is_day_off = 1 AND se.is_locked = 0
+             AND (se.notes IS NULL OR se.notes != 'Férias')
+             AND se.employee_id IN (SELECT id FROM employees WHERE active = 1)`
+        )
+        .all(date);
 
-    // Passo 3 (emergência): força candidato seg_sex em Sáb/Dom — equipe insuficiente de dom_sab
-    for (const { folgaId, emp } of candidates) {
-      if (getEmployeeHours(db, emp.id, startDate, endDate) >= COVERAGE_HOURS_CAP) continue;
-      const shift = getShiftForEmp(emp);
-      db.prepare('UPDATE schedule_entries SET is_day_off = 0, shift_type_id = ? WHERE id = ?')
-        .run(shift.id, folgaId);
-      warnings.push({
-        type: 'sem_motorista_forcado_seg_sex',
-        date,
-        employee: emp.name,
-        message: `${date}: cobertura de emergência para ${emp.name} (seg_sex forçado em fim de semana — equipe insuficiente)`,
-      });
-      forced = true;
-      break;
-    }
-    if (!forced) {
-      warnings.push({ type: 'sem_motorista', date, message: `${date}: nenhum motorista escalado` });
+      if (folgas.length === 0) {
+        if (filled === 0) {
+          warnings.push({ type: 'sem_motorista', date, message: `${date}: nenhum motorista escalado` });
+        } else {
+          warnings.push({
+            type: 'cobertura_minima_insuficiente',
+            date,
+            message: `${date}: apenas ${filled}/${MIN_DAILY_COVERAGE} motoristas — sem candidatos disponíveis`,
+          });
+        }
+        break;
+      }
+
+      // Ordena candidatos por mais dias desde o último trabalho (mais descansado primeiro)
+      const candidates = folgas
+        .map((f) => {
+          const emp = employees.find((e) => e.id === f.employee_id);
+          if (!emp) return null;
+          const lastWork = db
+            .prepare(
+              `SELECT date FROM schedule_entries
+               WHERE employee_id = ? AND date < ? AND is_day_off = 0
+               ORDER BY date DESC LIMIT 1`
+            )
+            .get(emp.id, date);
+          const daysSince = lastWork
+            ? Math.round(
+                (new Date(date + 'T12:00:00Z') - new Date(lastWork.date + 'T12:00:00Z')) /
+                  86_400_000
+              )
+            : 999;
+          return { folgaId: f.id, emp, daysSince };
+        })
+        .filter(Boolean)
+        .sort((a, b) => b.daysSince - a.daysSince);
+
+      const isSecond = filled > 0;
+
+      // Passo 1: com restrições de descanso e cap de horas (respeita seg_sex)
+      let assigned = false;
+      for (const { folgaId, emp } of candidates) {
+        if (emp.work_schedule === 'seg_sex' && isWeekend) continue;
+        if (getEmployeeHours(db, emp.id, startDate, endDate) >= COVERAGE_HOURS_CAP) continue;
+        const shift = getShiftForEmp(emp);
+        if (!canAssignShift(db, emp.id, date, shift)) continue;
+        db.prepare('UPDATE schedule_entries SET is_day_off = 0, shift_type_id = ? WHERE id = ?')
+          .run(shift.id, folgaId);
+        filled++;
+        assigned = true;
+        break;
+      }
+      if (assigned) continue;
+
+      // Passo 2: forçado — ignora restrições de descanso e consecutivos (respeita seg_sex e cap)
+      let forced = false;
+      for (const { folgaId, emp } of candidates) {
+        if (emp.work_schedule === 'seg_sex' && isWeekend) continue;
+        if (getEmployeeHours(db, emp.id, startDate, endDate) >= COVERAGE_HOURS_CAP) continue;
+        const shift = getShiftForEmp(emp);
+        db.prepare('UPDATE schedule_entries SET is_day_off = 0, shift_type_id = ? WHERE id = ?')
+          .run(shift.id, folgaId);
+        warnings.push({
+          type: isSecond ? 'segundo_motorista_forcado' : 'sem_motorista_forcado',
+          date,
+          employee: emp.name,
+          message: isSecond
+            ? `${date}: segundo motorista forçado para ${emp.name} (cobertura mínima ${MIN_DAILY_COVERAGE}/dia)`
+            : `${date}: cobertura diária forçada para ${emp.name} (restrições de descanso ignoradas)`,
+        });
+        filled++;
+        forced = true;
+        break;
+      }
+      if (forced) continue;
+
+      // Passo 3 (emergência): força candidato seg_sex em Sáb/Dom — equipe insuficiente de dom_sab
+      for (const { folgaId, emp } of candidates) {
+        if (getEmployeeHours(db, emp.id, startDate, endDate) >= COVERAGE_HOURS_CAP) continue;
+        const shift = getShiftForEmp(emp);
+        db.prepare('UPDATE schedule_entries SET is_day_off = 0, shift_type_id = ? WHERE id = ?')
+          .run(shift.id, folgaId);
+        warnings.push({
+          type: 'sem_motorista_forcado_seg_sex',
+          date,
+          employee: emp.name,
+          message: `${date}: cobertura de emergência para ${emp.name} (seg_sex forçado em fim de semana — equipe insuficiente)`,
+        });
+        filled++;
+        forced = true;
+        break;
+      }
+      if (!forced) {
+        if (filled === 0) {
+          warnings.push({ type: 'sem_motorista', date, message: `${date}: nenhum motorista escalado` });
+        } else {
+          warnings.push({
+            type: 'cobertura_minima_insuficiente',
+            date,
+            message: `${date}: apenas ${filled}/${MIN_DAILY_COVERAGE} motoristas — equipe insuficiente`,
+          });
+        }
+        break;
+      }
     }
   }
 }

--- a/backend/src/tests/scheduleGenerator.unit.test.js
+++ b/backend/src/tests/scheduleGenerator.unit.test.js
@@ -128,32 +128,37 @@ describe('enforceDailyCoverage', () => {
     return db.prepare('SELECT * FROM schedule_entries WHERE employee_id = ? AND date = ?').get(employee_id, date);
   }
 
-  it('converte folga em turno quando dia não tem motorista (passo 1 — sem forçar)', () => {
-    // Sem entradas adjacentes → prevEntry e nextEntry são null → canAssignShift retorna true
-    const emp = createEmployee(db, { name: 'Ana', setor: 'Transporte Ambulância' });
-    insertEntry(db, { employee_id: emp.id, date: '2025-01-05', is_day_off: 1, shift_type_id: null });
+  it('converte 2 folgas em turnos sem warning quando dia não tem motorista (passo 1 ambos)', () => {
+    // 2 funcionários com folgas → ambos atribuídos via passo 1 sem forçar → 0 warnings
+    const emp1 = createEmployee(db, { name: 'Ana', setor: 'Transporte Ambulância' });
+    const emp2 = createEmployee(db, { name: 'Beatriz', setor: 'Transporte Ambulância' });
+    insertEntry(db, { employee_id: emp1.id, date: '2025-01-05', is_day_off: 1, shift_type_id: null });
+    insertEntry(db, { employee_id: emp2.id, date: '2025-01-05', is_day_off: 1, shift_type_id: null });
 
-    const employees = [{ ...emp, setores: ['Transporte Ambulância'] }];
-    const sectorMap = { [emp.id]: ['Transporte Ambulância'] };
+    const employees = [
+      { ...emp1, setores: ['Transporte Ambulância'] },
+      { ...emp2, setores: ['Transporte Ambulância'] },
+    ];
+    const sectorMap = {
+      [emp1.id]: ['Transporte Ambulância'],
+      [emp2.id]: ['Transporte Ambulância'],
+    };
     const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
     const warnings = [];
 
     enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-05'], warnings);
 
-    const entry = getEntry(db, emp.id, '2025-01-05');
-    expect(entry.is_day_off).toBe(0);
-    expect(entry.shift_type_id).toBeTruthy();
-    expect(warnings).toHaveLength(0); // cobertura sem force: sem warning
+    expect(getEntry(db, emp1.id, '2025-01-05').is_day_off).toBe(0);
+    expect(getEntry(db, emp2.id, '2025-01-05').is_day_off).toBe(0);
+    expect(warnings).toHaveLength(0);
   });
 
   it('emite warning sem_motorista_forcado quando único candidato viola restrições de descanso', () => {
-    // Turnos com start_time para que canAssignShift rejeite por descanso insuficiente
-    // Funcionário com poucas horas (<160h) para não ser bloqueado pelo cap
+    // Jan 4 noturno (termina Jan 5 07:00); Jan 5 folga — 12h rest → canAssign rejeita (< 24h)
+    // Passo 2 força Bruno; depois não há mais folgas → cobertura_minima_insuficiente
     const noturno = db.prepare("SELECT * FROM shift_types WHERE name = 'Noturno'").get();
     const emp = createEmployee(db, { name: 'Bruno', setor: 'Transporte Ambulância' });
 
-    // Apenas 1 dia de trabalho anterior (12h < 160h cap) + folga adjacente
-    // Jan 4 noturno (termina Jan 5 07:00); Jan 5 folga — 12h rest → canAssign rejeita (< 24h)
     insertEntry(db, { employee_id: emp.id, date: '2025-01-04', is_day_off: 0, shift_type_id: noturno.id });
     insertEntry(db, { employee_id: emp.id, date: '2025-01-05', is_day_off: 1, shift_type_id: null });
 
@@ -164,9 +169,10 @@ describe('enforceDailyCoverage', () => {
 
     enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-05'], warnings);
 
-    // Deve ter sido forçado — warning emitido
+    // 1º motorista forçado
     expect(warnings.some(w => w.type === 'sem_motorista_forcado')).toBe(true);
-    // E o dia deve ter sido coberto mesmo assim
+    // Sem 2º candidato → cobertura_minima_insuficiente
+    expect(warnings.some(w => w.type === 'cobertura_minima_insuficiente')).toBe(true);
     const entry = getEntry(db, emp.id, '2025-01-05');
     expect(entry.is_day_off).toBe(0);
   });
@@ -201,18 +207,21 @@ describe('enforceDailyCoverage', () => {
 
     enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-05'], warnings);
 
-    // Passo 3: cobertura garantida mesmo sendo seg_sex
+    // Passo 3: 1º motorista forçado mesmo sendo seg_sex
     const entry = getEntry(db, empId, '2025-01-05');
-    expect(entry.is_day_off).toBe(0); // convertido pelo passo 3
+    expect(entry.is_day_off).toBe(0);
     expect(warnings.some(w => w.type === 'sem_motorista_forcado_seg_sex')).toBe(true);
-    expect(warnings.some(w => w.type === 'sem_motorista')).toBe(false); // dia foi coberto
+    expect(warnings.some(w => w.type === 'sem_motorista')).toBe(false); // dia foi coberto (parcialmente)
+    // Não há 2º candidato → cobertura_minima_insuficiente
+    expect(warnings.some(w => w.type === 'cobertura_minima_insuficiente')).toBe(true);
   });
 
-  it('passo 3 não é acionado quando há dom_sab disponível no Sábado', () => {
-    // Sáb Jan 4, 2025: 1 seg_sex (passo 1/2 o ignora) + 1 dom_sab (passo 2 o pega)
+  it('passo 3 não é acionado quando há 2 dom_sab disponíveis no Sábado', () => {
+    // Sáb Jan 4, 2025: 1 seg_sex + 2 dom_sab → 2 dom_sab cobrem o dia, seg_sex preservado
     const empSegSex = db.prepare("INSERT INTO employees (name, cargo, work_schedule) VALUES ('Eduardo', 'Motorista', 'seg_sex')").run();
-    const empDomSab = db.prepare("INSERT INTO employees (name, cargo, work_schedule) VALUES ('Fernanda', 'Motorista', 'dom_sab')").run();
-    for (const id of [empSegSex.lastInsertRowid, empDomSab.lastInsertRowid]) {
+    const empDomSab1 = db.prepare("INSERT INTO employees (name, cargo, work_schedule) VALUES ('Fernanda', 'Motorista', 'dom_sab')").run();
+    const empDomSab2 = db.prepare("INSERT INTO employees (name, cargo, work_schedule) VALUES ('Gabriela', 'Motorista', 'dom_sab')").run();
+    for (const id of [empSegSex.lastInsertRowid, empDomSab1.lastInsertRowid, empDomSab2.lastInsertRowid]) {
       db.prepare('INSERT INTO employee_sectors (employee_id, setor) VALUES (?, ?)').run(id, 'Transporte Ambulância');
       db.prepare('INSERT INTO employee_rest_rules (employee_id, min_rest_hours) VALUES (?, 24)').run(id);
       insertEntry(db, { employee_id: id, date: '2025-01-04', is_day_off: 1, shift_type_id: null });
@@ -226,28 +235,136 @@ describe('enforceDailyCoverage', () => {
 
     enforceDailyCoverage(db, allEmps, sectorMap, shiftTypes, ['2025-01-04'], warnings);
 
-    // dom_sab (Fernanda) deve ter sido escalada; seg_sex (Eduardo) não tocado
-    const entrySegSex = getEntry(db, empSegSex.lastInsertRowid, '2025-01-04');
-    const entryDomSab = getEntry(db, empDomSab.lastInsertRowid, '2025-01-04');
-    expect(entryDomSab.is_day_off).toBe(0); // Fernanda trabalha
+    // Fernanda e Gabriela (dom_sab) trabalham; Eduardo (seg_sex) preservado
+    const entrySegSex  = getEntry(db, empSegSex.lastInsertRowid,  '2025-01-04');
+    const entryDomSab1 = getEntry(db, empDomSab1.lastInsertRowid, '2025-01-04');
+    const entryDomSab2 = getEntry(db, empDomSab2.lastInsertRowid, '2025-01-04');
+    expect(entryDomSab1.is_day_off).toBe(0);
+    expect(entryDomSab2.is_day_off).toBe(0);
     expect(entrySegSex.is_day_off).toBe(1); // Eduardo preservado
     expect(warnings.some(w => w.type === 'sem_motorista_forcado_seg_sex')).toBe(false);
+    expect(warnings).toHaveLength(0);
   });
 
-  it('não toca dias que já têm motorista escalado', () => {
+  it('não toca dias que já têm MIN_DAILY_COVERAGE (2) motoristas escalados', () => {
     const noturno = db.prepare("SELECT * FROM shift_types WHERE name = 'Noturno'").get();
-    const emp = createEmployee(db, { name: 'Eva', setor: 'Transporte Ambulância' });
-    insertEntry(db, { employee_id: emp.id, date: '2025-01-15', is_day_off: 0, shift_type_id: noturno.id });
+    const emp1 = createEmployee(db, { name: 'Eva', setor: 'Transporte Ambulância' });
+    const emp2 = createEmployee(db, { name: 'Felipe', setor: 'Transporte Ambulância' });
+    insertEntry(db, { employee_id: emp1.id, date: '2025-01-15', is_day_off: 0, shift_type_id: noturno.id });
+    insertEntry(db, { employee_id: emp2.id, date: '2025-01-15', is_day_off: 0, shift_type_id: noturno.id });
 
-    const employees = [{ ...emp, setores: ['Transporte Ambulância'] }];
-    const sectorMap = { [emp.id]: ['Transporte Ambulância'] };
+    const employees = [
+      { ...emp1, setores: ['Transporte Ambulância'] },
+      { ...emp2, setores: ['Transporte Ambulância'] },
+    ];
+    const sectorMap = {
+      [emp1.id]: ['Transporte Ambulância'],
+      [emp2.id]: ['Transporte Ambulância'],
+    };
     const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
     const warnings = [];
 
     enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-15'], warnings);
 
     expect(warnings).toHaveLength(0);
-    const entry = getEntry(db, emp.id, '2025-01-15');
-    expect(entry.is_day_off).toBe(0); // permanece trabalho
+    expect(getEntry(db, emp1.id, '2025-01-15').is_day_off).toBe(0);
+    expect(getEntry(db, emp2.id, '2025-01-15').is_day_off).toBe(0);
+  });
+
+  it('dia com 1 motorista já escalado e 1 folga disponível → segundo atribuído sem warning', () => {
+    // initialCount=1 < MIN_DAILY_COVERAGE=2 → entra no loop e atribui o 2º sem forçar
+    const noturno = db.prepare("SELECT * FROM shift_types WHERE name = 'Noturno'").get();
+    const emp1 = createEmployee(db, { name: 'Gabi', setor: 'Transporte Ambulância' });
+    const emp2 = createEmployee(db, { name: 'Hugo', setor: 'Transporte Ambulância' });
+    insertEntry(db, { employee_id: emp1.id, date: '2025-01-06', is_day_off: 0, shift_type_id: noturno.id });
+    insertEntry(db, { employee_id: emp2.id, date: '2025-01-06', is_day_off: 1, shift_type_id: null });
+
+    const employees = [
+      { ...emp1, setores: ['Transporte Ambulância'] },
+      { ...emp2, setores: ['Transporte Ambulância'] },
+    ];
+    const sectorMap = {
+      [emp1.id]: ['Transporte Ambulância'],
+      [emp2.id]: ['Transporte Ambulância'],
+    };
+    const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
+    const warnings = [];
+
+    enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-06'], warnings);
+
+    expect(getEntry(db, emp2.id, '2025-01-06').is_day_off).toBe(0); // Hugo atribuído
+    expect(warnings).toHaveLength(0); // sem forçar → sem warning
+  });
+
+  it('dia com 1 motorista escalado, único candidato viola descanso → segundo_motorista_forcado', () => {
+    // emp1 já trabalhando; emp2 tem folga mas violaria descanso → forçado via passo 2
+    const noturno = db.prepare("SELECT * FROM shift_types WHERE name = 'Noturno'").get();
+    const emp1 = createEmployee(db, { name: 'Iara', setor: 'Transporte Ambulância' });
+    const emp2 = createEmployee(db, { name: 'Jonas', setor: 'Transporte Ambulância' });
+    insertEntry(db, { employee_id: emp1.id, date: '2025-01-06', is_day_off: 0, shift_type_id: noturno.id });
+    // Jonas trabalhou no noturno anterior → canAssignShift rejeita no passo 1
+    insertEntry(db, { employee_id: emp2.id, date: '2025-01-05', is_day_off: 0, shift_type_id: noturno.id });
+    insertEntry(db, { employee_id: emp2.id, date: '2025-01-06', is_day_off: 1, shift_type_id: null });
+
+    const employees = [
+      { ...emp1, setores: ['Transporte Ambulância'] },
+      { ...emp2, setores: ['Transporte Ambulância'] },
+    ];
+    const sectorMap = {
+      [emp1.id]: ['Transporte Ambulância'],
+      [emp2.id]: ['Transporte Ambulância'],
+    };
+    const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
+    const warnings = [];
+
+    enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-06'], warnings);
+
+    expect(getEntry(db, emp2.id, '2025-01-06').is_day_off).toBe(0); // Jonas forçado
+    expect(warnings.some(w => w.type === 'segundo_motorista_forcado' && w.employee === 'Jonas')).toBe(true);
+    expect(warnings.some(w => w.type === 'sem_motorista_forcado')).toBe(false); // não é 1º
+  });
+
+  it('dia com 0 motoristas e apenas 1 folga → 1 atribuído + cobertura_minima_insuficiente', () => {
+    // Só 1 funcionário disponível como folga → preenche 1, não consegue 2
+    const emp = createEmployee(db, { name: 'Karina', setor: 'Transporte Ambulância' });
+    insertEntry(db, { employee_id: emp.id, date: '2025-01-07', is_day_off: 1, shift_type_id: null });
+
+    const employees = [{ ...emp, setores: ['Transporte Ambulância'] }];
+    const sectorMap = { [emp.id]: ['Transporte Ambulância'] };
+    const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
+    const warnings = [];
+
+    enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-07'], warnings);
+
+    expect(getEntry(db, emp.id, '2025-01-07').is_day_off).toBe(0); // Karina atribuída
+    expect(warnings.some(w => w.type === 'cobertura_minima_insuficiente' && w.date === '2025-01-07')).toBe(true);
+    expect(warnings.some(w => w.type === 'sem_motorista')).toBe(false); // 1 motorista cobriu parcialmente
+  });
+
+  it('dia com 1 motorista escalado e sem folgas disponíveis → cobertura_minima_insuficiente', () => {
+    // emp1 trabalha; emp2 está de férias (locked notes=Férias) → sem candidatos para 2º
+    const noturno = db.prepare("SELECT * FROM shift_types WHERE name = 'Noturno'").get();
+    const emp1 = createEmployee(db, { name: 'Leo', setor: 'Transporte Ambulância' });
+    const emp2 = createEmployee(db, { name: 'Marta', setor: 'Transporte Ambulância' });
+    insertEntry(db, { employee_id: emp1.id, date: '2025-01-08', is_day_off: 0, shift_type_id: noturno.id });
+    insertEntry(db, { employee_id: emp2.id, date: '2025-01-08', is_day_off: 1, shift_type_id: null, notes: 'Férias' });
+
+    const employees = [
+      { ...emp1, setores: ['Transporte Ambulância'] },
+      { ...emp2, setores: ['Transporte Ambulância'] },
+    ];
+    const sectorMap = {
+      [emp1.id]: ['Transporte Ambulância'],
+      [emp2.id]: ['Transporte Ambulância'],
+    };
+    const shiftTypes = db.prepare('SELECT * FROM shift_types').all();
+    const warnings = [];
+
+    enforceDailyCoverage(db, employees, sectorMap, shiftTypes, ['2025-01-08'], warnings);
+
+    expect(getEntry(db, emp1.id, '2025-01-08').is_day_off).toBe(0); // Leo permanece
+    expect(getEntry(db, emp2.id, '2025-01-08').is_day_off).toBe(1); // Marta em férias intocada
+    expect(warnings.some(w => w.type === 'cobertura_minima_insuficiente' && w.date === '2025-01-08')).toBe(true);
+    expect(warnings.some(w => w.type === 'sem_motorista')).toBe(false);
   });
 });


### PR DESCRIPTION
## Resumo

- Implementa Regra 42: todo dia do mês deve ter no mínimo 2 motoristas escalados
- Adiciona constante  após as demais constantes do gerador
- Refatora : substitui lógica single-pass por loop , re-buscando folgas a cada iteração

## Novos warnings

| Tipo | Quando |
|------|--------|
|  | Passo 2 forçou o 2º+ motorista (violou restrições de descanso) |
|  | Não havia candidatos para atingir MIN_DAILY_COVERAGE |

## Plano de teste

- 128/128 testes passando (7 arquivos)
- 3 testes existentes atualizados para compatibilidade com MIN_DAILY_COVERAGE=2
- 4 novos testes adicionados:
  - Dia com 1 motorista já escalado + 1 folga → 2º atribuído sem warning
  - Dia com 1 motorista escalado + candidato viola descanso →   - Dia com 0 motoristas + apenas 1 folga → 1 atribuído +   - Dia com 1 motorista + sem folgas → 
## Logs de execução

\
Desenvolvedor Pleno