### PR TITLE
feat(generator): ciclo 36h/42h CLT rotativo via cycle_month — closes #41

### DIFF
--- a/backend/src/db/database.js
+++ b/backend/src/db/database.js
@@ -49,6 +49,7 @@ function initSchema() {
       cargo TEXT NOT NULL,
       work_schedule TEXT NOT NULL DEFAULT 'dom_sab',
       color TEXT NOT NULL DEFAULT '#6B7280',
+      cycle_month INTEGER NOT NULL DEFAULT 1,
       active INTEGER NOT NULL DEFAULT 1,
       created_at TEXT DEFAULT (datetime('now')),
       updated_at TEXT DEFAULT (datetime('now'))
@@ -127,6 +128,11 @@ function runMigrations() {
   // Add color to employees (old DBs)
   if (!empCols.includes('color')) {
     db.exec("ALTER TABLE employees ADD COLUMN color TEXT NOT NULL DEFAULT '#6B7280'");
+  }
+
+  // Add cycle_month to employees (Issue #41)
+  if (!empCols.includes('cycle_month')) {
+    db.exec('ALTER TABLE employees ADD COLUMN cycle_month INTEGER NOT NULL DEFAULT 1');
   }
 
   // Migrate setor column → employee_sectors table

--- a/backend/src/routes/employees.js
+++ b/backend/src/routes/employees.js
@@ -10,6 +10,7 @@ const SETORES_VALIDOS = [
 ];
 
 const WORK_SCHEDULES_VALIDOS = ['seg_sex', 'dom_sab'];
+const CYCLE_MONTHS_VALIDOS = [1, 2, 3];
 const COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/;
 
 /** Rejeita datas com componentes inválidos (ex: 2025-02-30 rola para março no V8). */
@@ -105,7 +106,7 @@ router.get('/:id', (req, res) => {
 // ── POST /api/employees ───────────────────────────────────────────────────────
 router.post('/', (req, res) => {
   const db = getDb();
-  const { name, setores, work_schedule = 'dom_sab', color = '#6B7280', restRules } = req.body;
+  const { name, setores, work_schedule = 'dom_sab', color = '#6B7280', cycle_month = 1, restRules } = req.body;
 
   if (!name) return res.status(400).json({ error: 'name é obrigatório' });
 
@@ -120,10 +121,14 @@ router.post('/', (req, res) => {
     return res.status(400).json({ error: 'color deve ser um hex válido (#RRGGBB)' });
   }
 
+  if (!CYCLE_MONTHS_VALIDOS.includes(Number(cycle_month))) {
+    return res.status(400).json({ error: 'cycle_month deve ser 1, 2 ou 3' });
+  }
+
   const employee = runTransaction(() => {
     const result = db
-      .prepare('INSERT INTO employees (name, cargo, work_schedule, color) VALUES (?, ?, ?, ?)')
-      .run(name.trim(), 'Motorista', work_schedule, color);
+      .prepare('INSERT INTO employees (name, cargo, work_schedule, color, cycle_month) VALUES (?, ?, ?, ?, ?)')
+      .run(name.trim(), 'Motorista', work_schedule, color, Number(cycle_month));
 
     const employeeId = result.lastInsertRowid;
 
@@ -154,7 +159,7 @@ router.post('/', (req, res) => {
 // ── PUT /api/employees/:id ────────────────────────────────────────────────────
 router.put('/:id', (req, res) => {
   const db = getDb();
-  const { name, setores, work_schedule, color, active, restRules } = req.body;
+  const { name, setores, work_schedule, color, cycle_month, active, restRules } = req.body;
   const id = parseInt(req.params.id);
 
   const employee = db.prepare('SELECT id FROM employees WHERE id = ?').get(id);
@@ -173,6 +178,10 @@ router.put('/:id', (req, res) => {
     return res.status(400).json({ error: 'color deve ser um hex válido (#RRGGBB)' });
   }
 
+  if (cycle_month !== undefined && !CYCLE_MONTHS_VALIDOS.includes(Number(cycle_month))) {
+    return res.status(400).json({ error: 'cycle_month deve ser 1, 2 ou 3' });
+  }
+
   runTransaction(() => {
     if (name !== undefined)
       db.prepare("UPDATE employees SET name = ?, updated_at = datetime('now') WHERE id = ?").run(name, id);
@@ -181,6 +190,9 @@ router.put('/:id', (req, res) => {
       db.prepare("UPDATE employees SET work_schedule = ?, updated_at = datetime('now') WHERE id = ?").run(work_schedule, id);
     if (color !== undefined)
       db.prepare("UPDATE employees SET color = ?, updated_at = datetime('now') WHERE id = ?").run(color, id);
+    if (cycle_month !== undefined)
+      db.prepare("UPDATE employees SET cycle_month = ?, updated_at = datetime('now') WHERE id = ?")
+        .run(Number(cycle_month), id);
     if (active !== undefined)
       db.prepare("UPDATE employees SET active = ?, updated_at = datetime('now') WHERE id = ?").run(active ? 1 : 0, id);
 

--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -31,6 +31,23 @@ export function isValidEmendado(prevShiftName, nextShiftName) {
 }
 
 /**
+ * Retorna o label contábil CLT da semana para um motorista.
+ * @param {number} cycleMonth - Fase do ciclo do motorista (1, 2 ou 3).
+ * @param {number} genMonth   - Mês da geração (1–12).
+ * @param {number} weekIndex  - Índice da semana no mês (0-based, clamped em 3).
+ * @returns {'36h' | '42h'}
+ */
+export function getWeekType(cycleMonth, genMonth, weekIndex) {
+  const patterns = [
+    ['36h', '42h', '42h', '36h'],  // fase 1
+    ['42h', '42h', '36h', '42h'],  // fase 2
+    ['42h', '36h', '42h', '42h'],  // fase 3
+  ];
+  const actualCycle = ((genMonth - 1 + cycleMonth - 1) % 3);
+  return patterns[actualCycle][Math.min(weekIndex, 3)];
+}
+
+/**
  * Main schedule generation algorithm (greedy + correction step)
  * Target: 160h/month per employee
  */
@@ -88,7 +105,7 @@ export async function generateSchedule({ month, year, overwriteLocked = false })
     const result = runTransaction(() => {
       return generateForEmployee(
         db, employee, shiftTypes, shiftMap, dates,
-        overwriteLocked, warnings, allVacationDates
+        overwriteLocked, warnings, allVacationDates, month
       );
     });
     results.push(result);
@@ -111,7 +128,7 @@ export async function generateSchedule({ month, year, overwriteLocked = false })
   return { results, warnings };
 }
 
-function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwriteLocked, warnings, allVacationDates) {
+function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwriteLocked, warnings, allVacationDates, genMonth) {
   const rules = db
     .prepare('SELECT * FROM employee_rest_rules WHERE employee_id = ?')
     .get(employee.id) || { min_rest_hours: MIN_REST_HOURS, preferred_shift_id: null };
@@ -211,8 +228,7 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
         lastShiftName = null;
       }
 
-      // Ciclo leve/pesada: 0→leve(3), 1→pesada(4), 2→pesada(4)
-      const maxTurnosNaSemana = wi % 3 === 0 ? 3 : 4;
+      const maxTurnosNaSemana = getWeekType(employee.cycle_month ?? 1, genMonth, wi) === '36h' ? 3 : 4;
       const maxWorkInWeek = Math.min(freeInWeek.length, maxTurnosNaSemana);
       const actualOffInWeek = freeInWeek.length - Math.max(0, maxWorkInWeek);
 
@@ -251,8 +267,7 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
     }
   } else {
     // Ambulância / Hemodiálise — plantão 12h, meta 160h/mês
-    const targetWorkDays = Math.round(remainingHours / baseShiftHours);
-    let workDaysPlanned = 0;
+    // Não-ADM: sempre 3 plantões/semana (label 36h/42h é apenas contábil CLT — correctHours afina)
 
     for (const week of weeks) {
       const vacInWeek = week.filter((d) => vacationDatesForEmp.has(d) && !lockedDates.has(d));
@@ -280,11 +295,10 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
         lastShiftName = null;
       }
 
-      const remainingWorkDays = targetWorkDays - workDaysPlanned;
       // Garante mínimo 1 folga/semana quando não há férias ou forced-off (Regra: máx 6 dias consecutivos)
       const existingOffInWeek = vacInWeek.length + forcedOff.length;
       const minOffNeeded = freeInWeek.length > 0 ? Math.max(0, 1 - existingOffInWeek) : 0;
-      const actualWorkInWeek = Math.min(freeInWeek.length - minOffNeeded, Math.max(0, remainingWorkDays));
+      const actualWorkInWeek = Math.min(freeInWeek.length - minOffNeeded, 3);
       const actualOffInWeek = freeInWeek.length - actualWorkInWeek;
 
       const selectedOff = selectOffDays(freeInWeek, actualOffInWeek);
@@ -307,7 +321,6 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
 
           lastShiftEnd = computeShiftEnd(date, shift);
           lastShiftName = shift.name;
-          workDaysPlanned++;
         } else {
           entries.push({ employee_id: employee.id, shift_type_id: null, date, is_day_off: 1, is_locked: 0, notes: null });
           consecutiveHours = 0;

--- a/backend/src/tests/employees.test.js
+++ b/backend/src/tests/employees.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import request from 'supertest';
 import app from '../app.js';
 import { freshDb, createEmployee } from './helpers.js';
+import { resetDb } from '../db/database.js';
 
 beforeEach(() => freshDb());
 
@@ -152,5 +153,63 @@ describe('DELETE /api/employees/:id', () => {
     freshDb();
     const res = await request(app).delete('/api/employees/9999');
     expect(res.status).toBe(404);
+  });
+});
+
+describe('cycle_month — POST/PUT validação', () => {
+  it('aceita cycle_month válido (1, 2, 3)', async () => {
+    for (const cm of [1, 2, 3]) {
+      const db = freshDb();
+      const res = await request(app).post('/api/employees').send({
+        name: `Motorista Ciclo ${cm}`,
+        setores: ['Transporte Ambulância'],
+        cycle_month: cm,
+      });
+      expect(res.status).toBe(201);
+      expect(res.body.cycle_month).toBe(cm);
+      resetDb();
+    }
+  });
+
+  it('rejeita cycle_month inválido no POST', async () => {
+    for (const cm of [0, 4, 'invalido']) {
+      freshDb();
+      const res = await request(app).post('/api/employees').send({
+        name: 'Teste',
+        setores: ['Transporte Ambulância'],
+        cycle_month: cm,
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/cycle_month/);
+      resetDb();
+    }
+  });
+
+  it('cycle_month default é 1 quando não fornecido', async () => {
+    freshDb();
+    const res = await request(app).post('/api/employees').send({
+      name: 'Sem Ciclo',
+      setores: ['Transporte Ambulância'],
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.cycle_month).toBe(1);
+    resetDb();
+  });
+
+  it('atualiza cycle_month via PUT', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Ciclo Update', setor: 'Transporte Ambulância' });
+    const res = await request(app).put(`/api/employees/${emp.id}`).send({ cycle_month: 3 });
+    expect(res.status).toBe(200);
+    expect(res.body.cycle_month).toBe(3);
+    resetDb();
+  });
+
+  it('rejeita cycle_month inválido no PUT', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Ciclo Inválido', setor: 'Transporte Ambulância' });
+    const res = await request(app).put(`/api/employees/${emp.id}`).send({ cycle_month: 5 });
+    expect(res.status).toBe(400);
+    resetDb();
   });
 });

--- a/backend/src/tests/scheduleGenerator.unit.test.js
+++ b/backend/src/tests/scheduleGenerator.unit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { isValidEmendado, correctHours, enforceDailyCoverage } from '../services/scheduleGenerator.js';
+import { isValidEmendado, correctHours, enforceDailyCoverage, getWeekType } from '../services/scheduleGenerator.js';
 import { freshDb, createEmployee } from './helpers.js';
 
 describe('isValidEmendado', () => {
@@ -366,5 +366,32 @@ describe('enforceDailyCoverage', () => {
     expect(getEntry(db, emp2.id, '2025-01-08').is_day_off).toBe(1); // Marta em férias intocada
     expect(warnings.some(w => w.type === 'cobertura_minima_insuficiente' && w.date === '2025-01-08')).toBe(true);
     expect(warnings.some(w => w.type === 'sem_motorista')).toBe(false);
+  });
+});
+
+describe('getWeekType', () => {
+  it('fase 1, mês 1, semana 0 → 36h', () => expect(getWeekType(1, 1, 0)).toBe('36h'));
+  it('fase 1, mês 1, semana 1 → 42h', () => expect(getWeekType(1, 1, 1)).toBe('42h'));
+  it('fase 1, mês 1, semana 2 → 42h', () => expect(getWeekType(1, 1, 2)).toBe('42h'));
+  it('fase 1, mês 1, semana 3 → 36h', () => expect(getWeekType(1, 1, 3)).toBe('36h'));
+
+  it('fase 2, mês 1, semana 0 → 42h', () => expect(getWeekType(2, 1, 0)).toBe('42h'));
+  it('fase 2, mês 1, semana 2 → 36h', () => expect(getWeekType(2, 1, 2)).toBe('36h'));
+
+  it('fase 3, mês 1, semana 1 → 36h', () => expect(getWeekType(3, 1, 1)).toBe('36h'));
+
+  it('weekIndex >= 4 é clamped em 3', () => {
+    expect(getWeekType(1, 1, 4)).toBe(getWeekType(1, 1, 3));
+    expect(getWeekType(1, 1, 5)).toBe(getWeekType(1, 1, 3));
+  });
+
+  it('ciclo fecha após 3 meses: fase 1 mês 4 == fase 1 mês 1', () => {
+    expect(getWeekType(1, 4, 0)).toBe(getWeekType(1, 1, 0));
+    expect(getWeekType(1, 4, 1)).toBe(getWeekType(1, 1, 1));
+  });
+
+  it('fase 1 mês 2: motorista está no 2º mês do ciclo → patterns[1]', () => {
+    expect(getWeekType(1, 2, 0)).toBe('42h');
+    expect(getWeekType(1, 2, 2)).toBe('36h');
   });
 });

--- a/frontend/src/components/employees/EmployeeForm.jsx
+++ b/frontend/src/components/employees/EmployeeForm.jsx
@@ -34,6 +34,7 @@ export default function EmployeeForm({ open, onOpenChange, employee, onSuccess }
       name: '',
       work_schedule: 'dom_sab',
       color: '#6B7280',
+      cycle_month: '1',
       preferred_shift_id: '',
       notes: '',
     },
@@ -50,6 +51,7 @@ export default function EmployeeForm({ open, onOpenChange, employee, onSuccess }
         name: employee?.name ?? '',
         work_schedule: employee?.work_schedule ?? 'dom_sab',
         color: employee?.color ?? '#6B7280',
+        cycle_month: String(employee?.cycle_month ?? 1),
         preferred_shift_id: employee?.restRules?.preferred_shift_id ?? '',
         notes: employee?.restRules?.notes ?? '',
       });
@@ -111,6 +113,7 @@ export default function EmployeeForm({ open, onOpenChange, employee, onSuccess }
         setores: selectedSetores,
         work_schedule: data.work_schedule,
         color: data.color,
+        cycle_month: parseInt(data.cycle_month),
         restRules: {
           preferred_shift_id: data.preferred_shift_id ? parseInt(data.preferred_shift_id) : null,
           notes: data.notes || null,
@@ -189,6 +192,19 @@ export default function EmployeeForm({ open, onOpenChange, employee, onSuccess }
                   <option value="seg_sex">Segunda a Sexta</option>
                 </select>
               </div>
+            </div>
+
+            {/* Ciclo CLT */}
+            <div>
+              <label className="label">Ciclo CLT</label>
+              <select className="input" {...register('cycle_month')}>
+                <option value="1">Mês 1 — 36/42/42/36h</option>
+                <option value="2">Mês 2 — 42/42/36/42h</option>
+                <option value="3">Mês 3 — 42/36/42/42h</option>
+              </select>
+              <p className="text-xs text-gray-400 mt-1">
+                Define a fase do ciclo de 3 meses (média 40h/sem pela CLT)
+              </p>
             </div>
 
             {/* Setores */}


### PR DESCRIPTION
## Resumo

- Novo campo `cycle_month` (1, 2 ou 3) em `employees` — define a fase do ciclo de 3 meses
- `getWeekType(cycleMonth, genMonth, weekIndex)` retorna label contábil CLT (`36h` | `42h`)
- **ADM**: troca `wi % 3 === 0 ? 3 : 4` por `getWeekType()` para determinar 3 ou 4 turnos/semana
- **Não-ADM**: sempre 3 plantões/semana (label é apenas contábil — `correctHours` afina para ~160h)
- Frontend: seletor "Ciclo CLT" no `EmployeeForm` (Mês 1 / Mês 2 / Mês 3)
- DB migration segura: `ALTER TABLE ADD COLUMN cycle_month DEFAULT 1`

## Testes

- Backend: +5 testes em `employees.test.js` (POST/PUT cycle_month válido/inválido/default)
- Backend: +10 testes em `scheduleGenerator.unit.test.js` (todos os casos de `getWeekType`)
- Total: 143 backend + 66 frontend = 209 testes, todos passando
- CI deve passar em todos os jobs

## Closes

Closes #41