### PR TITLE
feat(api): endpoint GET /api/schedules/generations para histórico de gerações

### DIFF
--- a/backend/src/routes/schedules.js
+++ b/backend/src/routes/schedules.js
@@ -4,6 +4,36 @@ import { generateSchedule } from '../services/scheduleGenerator.js';
 
 const router = Router();
 
+// GET /api/schedules/generations[?month=&year=]
+router.get('/generations', (req, res) => {
+  const db = getDb();
+  const { month, year } = req.query;
+
+  let sql = 'SELECT id, month, year, generated_at, params_json FROM schedule_generations';
+  const params = [];
+
+  if (month && year) {
+    sql += ' WHERE month = ? AND year = ?';
+    params.push(Number(month), Number(year));
+  } else if (month) {
+    sql += ' WHERE month = ?';
+    params.push(Number(month));
+  } else if (year) {
+    sql += ' WHERE year = ?';
+    params.push(Number(year));
+  }
+
+  sql += ' ORDER BY id DESC';
+
+  const rows = db.prepare(sql).all(...params);
+  const generations = rows.map(r => ({
+    ...r,
+    params_json: JSON.parse(r.params_json),
+  }));
+
+  res.json(generations);
+});
+
 // GET /api/schedules?month=X&year=X
 router.get('/', (req, res) => {
   const { month, year } = req.query;


### PR DESCRIPTION
## O que muda

Novo endpoint para consultar o histórico de gerações de escala.

### `GET /api/schedules/generations`

Retorna todas as gerações registradas em `schedule_generations`, em ordem decrescente de `id`.

**Query params opcionais:**
- `?month=2` — filtra pelo mês
- `?year=2026` — filtra pelo ano
- `?month=2&year=2026` — filtra por mês e ano

**Resposta:**

- `params_json` retornado como objeto (não string)
- Retorna `[]` sem erro quando não há gerações

## Implementação

- 1 rota adicionada em `backend/src/routes/schedules.js`
- Sem mudança de schema
- Testes existentes: todos passando

## Evidência

Todos os 221 testes (155 backend + 66 frontend) passaram após a mudança.

Desenvolvedor Pleno