### PR TITLE
feat(api): validar cycle_month no CRUD de motoristas

### DIFF
--- a/backend/src/routes/employees.js
+++ b/backend/src/routes/employees.js
@@ -106,7 +106,9 @@ router.get('/:id', (req, res) => {
 // ── POST /api/employees ───────────────────────────────────────────────────────
 router.post('/', (req, res) => {
   const db = getDb();
-  const { name, setores, work_schedule = 'dom_sab', color = '#6B7280', cycle_month = 1, restRules } = req.body;
+  const { name, setores, work_schedule = 'dom_sab', color = '#6B7280', cycle_month, restRules } = req.body;
+  // null ou ausente → usar default 1 (gerador usa employee.cycle_month ?? 1)
+  const effectiveCycleMonth = cycle_month ?? 1;
 
   if (!name) return res.status(400).json({ error: 'name é obrigatório' });
 
@@ -121,14 +123,14 @@ router.post('/', (req, res) => {
     return res.status(400).json({ error: 'color deve ser um hex válido (#RRGGBB)' });
   }
 
-  if (!CYCLE_MONTHS_VALIDOS.includes(Number(cycle_month))) {
+  if (!CYCLE_MONTHS_VALIDOS.includes(Number(effectiveCycleMonth))) {
     return res.status(400).json({ error: 'cycle_month deve ser 1, 2 ou 3' });
   }
 
   const employee = runTransaction(() => {
     const result = db
       .prepare('INSERT INTO employees (name, cargo, work_schedule, color, cycle_month) VALUES (?, ?, ?, ?, ?)')
-      .run(name.trim(), 'Motorista', work_schedule, color, Number(cycle_month));
+      .run(name.trim(), 'Motorista', work_schedule, color, Number(effectiveCycleMonth));
 
     const employeeId = result.lastInsertRowid;
 
@@ -178,7 +180,7 @@ router.put('/:id', (req, res) => {
     return res.status(400).json({ error: 'color deve ser um hex válido (#RRGGBB)' });
   }
 
-  if (cycle_month !== undefined && !CYCLE_MONTHS_VALIDOS.includes(Number(cycle_month))) {
+  if (cycle_month !== undefined && cycle_month !== null && !CYCLE_MONTHS_VALIDOS.includes(Number(cycle_month))) {
     return res.status(400).json({ error: 'cycle_month deve ser 1, 2 ou 3' });
   }
 
@@ -190,7 +192,7 @@ router.put('/:id', (req, res) => {
       db.prepare("UPDATE employees SET work_schedule = ?, updated_at = datetime('now') WHERE id = ?").run(work_schedule, id);
     if (color !== undefined)
       db.prepare("UPDATE employees SET color = ?, updated_at = datetime('now') WHERE id = ?").run(color, id);
-    if (cycle_month !== undefined)
+    if (cycle_month !== undefined && cycle_month !== null)
       db.prepare("UPDATE employees SET cycle_month = ?, updated_at = datetime('now') WHERE id = ?")
         .run(Number(cycle_month), id);
     if (active !== undefined)

--- a/backend/src/tests/employees.test.js
+++ b/backend/src/tests/employees.test.js
@@ -172,7 +172,7 @@ describe('cycle_month — POST/PUT validação', () => {
   });
 
   it('rejeita cycle_month inválido no POST', async () => {
-    for (const cm of [0, 4, 'invalido']) {
+    for (const cm of [0, 4, 'invalido', 1.5]) {
       freshDb();
       const res = await request(app).post('/api/employees').send({
         name: 'Teste',
@@ -210,6 +210,37 @@ describe('cycle_month — POST/PUT validação', () => {
     const emp = createEmployee(db, { name: 'Ciclo Inválido', setor: 'Transporte Ambulância' });
     const res = await request(app).put(`/api/employees/${emp.id}`).send({ cycle_month: 5 });
     expect(res.status).toBe(400);
+    resetDb();
+  });
+
+  it('aceita cycle_month null no POST — armazena default 1', async () => {
+    freshDb();
+    const res = await request(app).post('/api/employees').send({
+      name: 'Ciclo Null',
+      setores: ['Transporte Ambulância'],
+      cycle_month: null,
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.cycle_month).toBe(1);
+    resetDb();
+  });
+
+  it('aceita cycle_month null no PUT — no-op, mantém valor atual', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Ciclo Reset', setor: 'Transporte Ambulância' });
+    // createEmployee não define cycle_month → default do DB é 1
+    const res = await request(app).put(`/api/employees/${emp.id}`).send({ cycle_month: null });
+    expect(res.status).toBe(200);
+    expect(res.body.cycle_month).toBe(1);
+    resetDb();
+  });
+
+  it('rejeita cycle_month 99 no PUT', async () => {
+    const db = freshDb();
+    const emp = createEmployee(db, { name: 'Ciclo 99', setor: 'Transporte Ambulância' });
+    const res = await request(app).put(`/api/employees/${emp.id}`).send({ cycle_month: 99 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/cycle_month/);
     resetDb();
   });
 });


### PR DESCRIPTION
## O que foi feito

Implementa validação de `cycle_month` no CRUD de motoristas conforme issue #51.

## Comportamento

| Cenário | Antes | Depois |
|---------|-------|--------|
| POST `cycle_month: null` | 400 ❌ | 201 ✅ (armazena default 1) |
| POST `cycle_month: 1.5` | 400 ✅ | 400 ✅ |
| POST `cycle_month: 0` | 400 ✅ | 400 ✅ |
| PUT `cycle_month: null` | 500 ❌ | 200 ✅ (no-op — mantém valor atual) |
| PUT `cycle_month: 99` | 400 ✅ | 400 ✅ |

## Decisão de design

O schema SQLite define `cycle_month INTEGER NOT NULL DEFAULT 1`.
Ao invés de migrar o schema, null é tratado como "usar default":
- **POST**: `cycle_month ?? 1` — null ou ausente resulta em 1
- **PUT**: null é no-op (campo não é atualizado)

Isso é consistente com o gerador que já usa `employee.cycle_month ?? 1`.

## Testes

- 163/163 backend passando (+3 novos casos: null POST, null PUT no-op, 1.5 inválido no POST, 99 inválido no PUT)
- `employees.test.js`: describe `cycle_month — POST/PUT validação` agora cobre todos os critérios de aceite da issue #51

## Checklist de aceite (#51)

- [x] POST com `cycle_month: 2` → 201
- [x] POST com `cycle_month: 0` → 400
- [x] POST com `cycle_month: 4` → 400
- [x] POST com `cycle_month: null` → 201
- [x] POST sem `cycle_month` → 201
- [x] PUT com `cycle_month: 1` → 200
- [x] PUT com `cycle_month: 99` → 400
