### PR TITLE
feat(#65): turno extra 6h (Manhã/Tarde) para motorista NOTURNO em semana de 42h

### DIFF
--- a/backend/src/db/database.js
+++ b/backend/src/db/database.js
@@ -169,10 +169,16 @@ function seedShiftTypes() {
   runTransaction(() => {
     db.prepare(
       'INSERT INTO shift_types (name, start_time, end_time, duration_hours, color) VALUES (?, ?, ?, ?, ?)'
-    ).run('Diurno', '07:00', '19:00', 12, '#34D399');
+    ).run('Diurno',  '07:00', '19:00', 12, '#34D399');
     db.prepare(
       'INSERT INTO shift_types (name, start_time, end_time, duration_hours, color) VALUES (?, ?, ?, ?, ?)'
     ).run('Noturno', '19:00', '07:00', 12, '#818CF8');
+    db.prepare(
+      'INSERT INTO shift_types (name, start_time, end_time, duration_hours, color) VALUES (?, ?, ?, ?, ?)'
+    ).run('Manhã',   '07:00', '13:00',  6, '#FCD34D');
+    db.prepare(
+      'INSERT INTO shift_types (name, start_time, end_time, duration_hours, color) VALUES (?, ?, ?, ?, ?)'
+    ).run('Tarde',   '13:00', '19:00',  6, '#F97316');
   });
 }
 
@@ -188,6 +194,16 @@ function migrateShiftTimes() {
     ).run('Noturno', '19:00', '07:00', 12, '#818CF8');
     db.prepare("UPDATE shift_types SET start_time=?, end_time=?, duration_hours=? WHERE name=?")
       .run('19:00', '07:00', 12, 'Noturno');
+    db.prepare(
+      "INSERT OR IGNORE INTO shift_types (name, start_time, end_time, duration_hours, color) VALUES (?,?,?,?,?)"
+    ).run('Manhã', '07:00', '13:00', 6, '#FCD34D');
+    db.prepare("UPDATE shift_types SET start_time=?, end_time=?, duration_hours=? WHERE name=?")
+      .run('07:00', '13:00', 6, 'Manhã');
+    db.prepare(
+      "INSERT OR IGNORE INTO shift_types (name, start_time, end_time, duration_hours, color) VALUES (?,?,?,?,?)"
+    ).run('Tarde', '13:00', '19:00', 6, '#F97316');
+    db.prepare("UPDATE shift_types SET start_time=?, end_time=?, duration_hours=? WHERE name=?")
+      .run('13:00', '19:00', 6, 'Tarde');
   });
 }
 

--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -20,6 +20,8 @@ const SETOR_HEMO            = 'Transporte Hemodiálise';
 const SHIFT_ADM_NAME        = 'Administrativo'; // 10h
 const SHIFT_DIURNO_NAME     = 'Diurno';         // 12h (regra 16)
 const SHIFT_NOTURNO_NAME    = 'Noturno';        // 12h (regras 21/22)
+const SHIFT_MANHA_NAME      = 'Manhã';          //  6h (extra 42h — issue #65)
+const SHIFT_TARDE_NAME      = 'Tarde';          //  6h (extra 42h — issue #65)
 
 /**
  * Verifica se dois turnos formam um emendado válido (sem descanso).
@@ -155,6 +157,10 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
   const isAdm = setores.includes(SETOR_ADM);
   const isSegSex = employee.work_schedule === 'seg_sex';
 
+  // Turnos de 6h (Manhã/Tarde) nunca são selecionados automaticamente pelo
+  // selectShift no ciclo normal de trabalho — somente via lógica extra-42h (#65).
+  const twelveHourShifts = shiftTypes.filter((s) => s.duration_hours === DEFAULT_SHIFT_HOURS);
+
   // Vacation dates for this employee
   const vacationDatesForEmp = new Set(
     dates.filter((d) => allVacationDates.has(`${employee.id}:${d}`))
@@ -236,7 +242,7 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
       const selectedWork = freeInWeek.filter((d) => !selectedOff.includes(d));
 
       for (const date of selectedWork) {
-        const shift = selectShift(shiftTypes, preferredShift, lastShiftEnd, lastShiftName, consecutiveHours, date);
+        const shift = selectShift(twelveHourShifts, preferredShift, lastShiftEnd, lastShiftName, consecutiveHours, date);
         if (shift) {
           entries.push({ employee_id: employee.id, shift_type_id: shift.id, date, is_day_off: 0, is_locked: 0, notes: null });
           totalHours += shift.duration_hours;
@@ -267,9 +273,16 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
     }
   } else {
     // Ambulância / Hemodiálise — plantão 12h, meta 160h/mês
-    // Não-ADM: sempre 3 plantões/semana (label 36h/42h é apenas contábil CLT — correctHours afina)
+    // Não-ADM: sempre 3 plantões/semana (label 36h/42h determina se há turno extra 6h).
+    // Semana 42h + motorista NOTURNO → adiciona 1 turno extra de 6h (Manhã ou Tarde) — issue #65.
 
-    for (const week of weeks) {
+    const isNoturno = preferredShift?.name === SHIFT_NOTURNO_NAME;
+    const manhaShift = shiftTypes.find((s) => s.name === SHIFT_MANHA_NAME);
+    const tardeShift = shiftTypes.find((s) => s.name === SHIFT_TARDE_NAME);
+
+    for (let wi = 0; wi < weeks.length; wi++) {
+      const week = weeks[wi];
+
       const vacInWeek = week.filter((d) => vacationDatesForEmp.has(d) && !lockedDates.has(d));
       const forcedOff = isSegSex
         ? week.filter((d) => {
@@ -305,7 +318,7 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
       const selectedWork = freeInWeek.filter((d) => !selectedOff.includes(d));
 
       for (const date of selectedWork) {
-        const shift = selectShift(shiftTypes, preferredShift, lastShiftEnd, lastShiftName, consecutiveHours, date);
+        const shift = selectShift(twelveHourShifts, preferredShift, lastShiftEnd, lastShiftName, consecutiveHours, date);
         if (shift) {
           entries.push({ employee_id: employee.id, shift_type_id: shift.id, date, is_day_off: 0, is_locked: 0, notes: null });
           totalHours += shift.duration_hours;
@@ -332,6 +345,34 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
         entries.push({ employee_id: employee.id, shift_type_id: null, date, is_day_off: 1, is_locked: 0, notes: null });
         consecutiveHours = 0;
         lastShiftName = null;
+      }
+
+      // Issue #65: Motorista NOTURNO em semana de 42h recebe 1 turno extra de 6h (Manhã ou Tarde).
+      if (isNoturno && getWeekType(employee.cycle_month ?? 1, genMonth, wi) === '42h') {
+        const extraCandidates = [manhaShift, tardeShift].filter(Boolean);
+        let extraAdded = false;
+
+        for (const offDate of selectedOff) {
+          if (extraAdded) break;
+          if (lockedDates.has(offDate) || vacationDatesForEmp.has(offDate)) continue;
+
+          for (const extraShift of extraCandidates) {
+            if (!canAddExtraShiftInMemory(entries, offDate, extraShift, shiftMap)) continue;
+
+            // Modifica a entrada de folga existente para turno de trabalho
+            const offEntry = entries.find(
+              (e) => e.date === offDate && e.is_day_off === 1 && !e.is_locked
+            );
+            if (!offEntry) continue;
+
+            offEntry.is_day_off = 0;
+            offEntry.shift_type_id = extraShift.id;
+            offEntry.notes = null;
+            totalHours += extraShift.duration_hours;
+            extraAdded = true;
+            break;
+          }
+        }
       }
     }
   }
@@ -468,6 +509,55 @@ function canAssignShift(db, employeeId, date, shift) {
         return false;
       } else if (restHours < MIN_REST_HOURS) {
         return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * In-memory equivalent of canAssignShift — checks rest rules against the
+ * already-built entries array (before DB persistence).
+ * Used to validate the extra 6h shift in 42h weeks (issue #65).
+ */
+function canAddExtraShiftInMemory(entries, date, shift, shiftMap) {
+  const workEntries = entries
+    .filter((e) => !e.is_day_off && e.shift_type_id)
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  const prev = [...workEntries].reverse().find((e) => e.date < date);
+  if (prev) {
+    const prevShift = shiftMap[prev.shift_type_id];
+    if (prevShift) {
+      const prevEnd  = computeShiftEnd(prev.date, prevShift);
+      const newStart = computeShiftStart(date, shift);
+      if (prevEnd && newStart) {
+        const restHours = (newStart - prevEnd) / 3_600_000;
+        if (restHours === 0) {
+          if (!isValidEmendado(prevShift.name, shift.name)) return false;
+          if (prevShift.duration_hours + shift.duration_hours > MAX_CONSECUTIVE_HOURS) return false;
+        } else if (restHours < 0 || restHours < MIN_REST_HOURS) {
+          return false;
+        }
+      }
+    }
+  }
+
+  const next = workEntries.find((e) => e.date > date);
+  if (next) {
+    const nextShift = shiftMap[next.shift_type_id];
+    if (nextShift) {
+      const newEnd    = computeShiftEnd(date, shift);
+      const nextStart = computeShiftStart(next.date, nextShift);
+      if (newEnd && nextStart) {
+        const restHours = (nextStart - newEnd) / 3_600_000;
+        if (restHours === 0) {
+          if (!isValidEmendado(shift.name, nextShift.name)) return false;
+          if (shift.duration_hours + nextShift.duration_hours > MAX_CONSECUTIVE_HOURS) return false;
+        } else if (restHours < 0 || restHours < MIN_REST_HOURS) {
+          return false;
+        }
       }
     }
   }

--- a/backend/src/tests/noturno42h.test.js
+++ b/backend/src/tests/noturno42h.test.js
@@ -1,0 +1,215 @@
+/**
+ * test(generator): turno noturno em semana de 42h — issue #65
+ *
+ * Tester Senior (coberto pelo Desenvolvedor Pleno como parte do #65)
+ *
+ * Critérios de aceite:
+ *   - Motorista NOTURNO em semana 36h: apenas turnos de 12h (sem extra 6h)
+ *   - Motorista NOTURNO em semana 42h: 3 × 12h + 1 × 6h (Manhã ou Tarde)
+ *   - O turno extra de 6h respeita descanso mínimo de 24h (ou emendado válido) com o Noturno adjacente
+ *   - Motorista DIURNO em semana 42h: sem turno extra de 6h (regra exclusiva do NOTURNO)
+ *
+ * Calendário de referência — Fevereiro 2025 (28 dias):
+ *   Feb 1 = Sábado → Semana 0: [Feb 1]
+ *   Feb 2 = Domingo → Semana 1: [Feb 2–8]   (42h com cycle_month=3)
+ *   Feb 9 = Domingo → Semana 2: [Feb 9–15]  (42h com cycle_month=3)
+ *   Feb 16 = Domingo → Semana 3: [Feb 16–22] (36h com cycle_month=3)
+ *   Feb 23 = Domingo → Semana 4: [Feb 23–28] (36h com cycle_month=3)
+ *
+ * getWeekType(3, 2, wi):
+ *   actualCycle = (1 + 2) % 3 = 0 → patterns[0] = ['36h','42h','42h','36h']
+ *   wi=0 → 36h, wi=1 → 42h, wi=2 → 42h, wi=3 → 36h, wi=4 → 36h (clamped)
+ *
+ * Total esperado com cycle_month=3 em Feb/2025 (motorista NOTURNO):
+ *   Semana 0 (1 dia): 0 plantões (1 dia livre → min 1 folga → 0 trabalho)
+ *   Semanas 1 e 2 (42h): 3 × 12h + 1 × 6h = 42h cada
+ *   Semanas 3 e 4 (36h): 3 × 12h = 36h cada
+ *   Total = 0 + 42 + 42 + 36 + 36 = 156h → desvio = -4h (≤ ±6h → correctHours não altera)
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../app.js';
+import { freshDb } from './helpers.js';
+
+const FEV = { month: 2, year: 2025 };
+
+// Semanas de Fevereiro 2025 (baseadas em Domingo)
+const FEV_WEEK1 = ['2025-02-02','2025-02-03','2025-02-04','2025-02-05','2025-02-06','2025-02-07','2025-02-08'];
+const FEV_WEEK2 = ['2025-02-09','2025-02-10','2025-02-11','2025-02-12','2025-02-13','2025-02-14','2025-02-15'];
+const FEV_WEEK3 = ['2025-02-16','2025-02-17','2025-02-18','2025-02-19','2025-02-20','2025-02-21','2025-02-22'];
+const FEV_WEEK4 = ['2025-02-23','2025-02-24','2025-02-25','2025-02-26','2025-02-27','2025-02-28'];
+
+beforeEach(() => freshDb());
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function entriesInWeek(allEntries, empId, weekDates) {
+  return allEntries.filter((e) => e.employee_id === empId && weekDates.includes(e.date));
+}
+
+function workEntriesInWeek(allEntries, empId, weekDates) {
+  return entriesInWeek(allEntries, empId, weekDates).filter((e) => !e.is_day_off);
+}
+
+/** Cria motorista via API com preferred_shift por nome */
+async function createNoturnoEmployee(name, cycleMonth = 3) {
+  // Busca o id do turno Noturno a partir da lista de shift-types
+  const shiftsRes = await request(app).get('/api/shift-types');
+  const noturnoId = shiftsRes.body.find((s) => s.name === 'Noturno')?.id;
+  expect(noturnoId).toBeDefined();
+
+  const empRes = await request(app).post('/api/employees').send({
+    name,
+    setores: ['Transporte Ambulância'],
+    cycle_month: cycleMonth,
+    restRules: { preferred_shift_id: noturnoId, notes: null },
+  });
+  expect(empRes.status).toBe(201);
+  return { emp: empRes.body, noturnoId };
+}
+
+async function createDiurnoEmployee(name, cycleMonth = 3) {
+  const shiftsRes = await request(app).get('/api/shift-types');
+  const diurnoId = shiftsRes.body.find((s) => s.name === 'Diurno')?.id;
+  expect(diurnoId).toBeDefined();
+
+  const empRes = await request(app).post('/api/employees').send({
+    name,
+    setores: ['Transporte Ambulância'],
+    cycle_month: cycleMonth,
+    restRules: { preferred_shift_id: diurnoId, notes: null },
+  });
+  expect(empRes.status).toBe(201);
+  return { emp: empRes.body, diurnoId };
+}
+
+// ── Teste 1: Semana 36h — sem turno extra de 6h ───────────────────────────────
+
+describe('Regra #65 — semana 36h: NOTURNO sem turno extra', () => {
+  it('motorista NOTURNO em semana 36h (FEV_WEEK3 e FEV_WEEK4) não recebe turno extra de 6h', async () => {
+    const { emp } = await createNoturnoEmployee('Noturno 36h');
+
+    const genRes = await request(app).post('/api/schedules/generate').send(FEV);
+    expect(genRes.status).toBe(200);
+
+    const schedRes = await request(app).get(`/api/schedules?month=${FEV.month}&year=${FEV.year}`);
+    const allEntries = schedRes.body.entries;
+
+    // Semanas 36h: nenhum turno de 6h
+    const week3Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK3);
+    const week4Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK4);
+
+    const sixHourIn36 = [...week3Work, ...week4Work].filter((e) => e.duration_hours === 6);
+    expect(sixHourIn36).toHaveLength(0);
+
+    // Todos os turnos de trabalho nas semanas 36h são de 12h (NOTURNO)
+    const allWork36 = [...week3Work, ...week4Work];
+    allWork36.forEach((e) => {
+      expect(e.duration_hours).toBe(12);
+    });
+  });
+});
+
+// ── Teste 2: Semana 42h — 1 turno extra de 6h ────────────────────────────────
+
+describe('Regra #65 — semana 42h: NOTURNO com 1 turno extra de 6h', () => {
+  it('motorista NOTURNO em semana 42h (FEV_WEEK1) tem exatamente 1 turno de 6h (Manhã ou Tarde)', async () => {
+    const { emp } = await createNoturnoEmployee('Noturno 42h');
+
+    const genRes = await request(app).post('/api/schedules/generate').send(FEV);
+    expect(genRes.status).toBe(200);
+
+    const schedRes = await request(app).get(`/api/schedules?month=${FEV.month}&year=${FEV.year}`);
+    const allEntries = schedRes.body.entries;
+
+    const week1Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK1);
+    const sixHourEntries = week1Work.filter((e) => e.duration_hours === 6);
+
+    // Exatamente 1 turno de 6h na semana 42h
+    expect(sixHourEntries).toHaveLength(1);
+
+    // O turno extra é Manhã ou Tarde
+    const validNames = ['Manhã', 'Tarde'];
+    expect(validNames).toContain(sixHourEntries[0].shift_name);
+  });
+
+  it('motorista NOTURNO em semana 42h (FEV_WEEK2) tem exatamente 1 turno de 6h (Manhã ou Tarde)', async () => {
+    const { emp } = await createNoturnoEmployee('Noturno 42h W2');
+
+    await request(app).post('/api/schedules/generate').send(FEV);
+
+    const schedRes = await request(app).get(`/api/schedules?month=${FEV.month}&year=${FEV.year}`);
+    const allEntries = schedRes.body.entries;
+
+    const week2Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK2);
+    const sixHourEntries = week2Work.filter((e) => e.duration_hours === 6);
+
+    expect(sixHourEntries).toHaveLength(1);
+    expect(['Manhã', 'Tarde']).toContain(sixHourEntries[0].shift_name);
+  });
+});
+
+// ── Teste 3: Turno extra respeita descanso mínimo ────────────────────────────
+
+describe('Regra #65 — turno extra de 6h respeita descanso mínimo de 24h (ou emendado válido)', () => {
+  it('o turno extra de 6h na semana 42h tem ≥24h de descanso ou é emendado Noturno→Manhã válido', async () => {
+    const { emp } = await createNoturnoEmployee('Noturno Rest Check');
+
+    await request(app).post('/api/schedules/generate').send(FEV);
+
+    const schedRes = await request(app).get(`/api/schedules?month=${FEV.month}&year=${FEV.year}`);
+    const allEntries = schedRes.body.entries;
+    const empWork = allEntries
+      .filter((e) => e.employee_id === emp.id && !e.is_day_off)
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    // Encontra o turno extra de 6h em FEV_WEEK1
+    const extraEntry = allEntries.find(
+      (e) => e.employee_id === emp.id && FEV_WEEK1.includes(e.date) && e.duration_hours === 6
+    );
+    expect(extraEntry).toBeDefined();
+
+    // Encontra o turno imediatamente anterior ao extra
+    const extraDate = extraEntry.date;
+    const prevWork = empWork.filter((e) => e.date < extraDate).at(-1);
+
+    if (prevWork) {
+      // Calcula rest entre fim do turno anterior e início do extra
+      const prevEnd = new Date(`${prevWork.date}T${prevWork.start_time}:00`).getTime()
+        + prevWork.duration_hours * 3_600_000;
+      const extraStart = new Date(`${extraDate}T${extraEntry.start_time}:00`).getTime();
+      const restHours = (extraStart - prevEnd) / 3_600_000;
+
+      // Emendado válido: Noturno→Manhã (0h rest, 18h total ≤ 18h) OU descanso ≥ 24h
+      const isEmendadoNoturnoManha =
+        restHours === 0 &&
+        prevWork.shift_name === 'Noturno' &&
+        extraEntry.shift_name === 'Manhã' &&
+        prevWork.duration_hours + extraEntry.duration_hours <= 18;
+
+      expect(isEmendadoNoturnoManha || restHours >= 24).toBe(true);
+    }
+    // Se não há turno anterior (extra é o primeiro), sem restrição
+  });
+});
+
+// ── Teste 4: Motorista DIURNO não recebe extra na semana 42h ─────────────────
+
+describe('Regra #65 — motorista DIURNO não recebe turno extra de 6h', () => {
+  it('motorista DIURNO em semana 42h não tem turno de 6h (regra exclusiva do NOTURNO)', async () => {
+    const { emp } = await createDiurnoEmployee('Diurno 42h');
+
+    await request(app).post('/api/schedules/generate').send(FEV);
+
+    const schedRes = await request(app).get(`/api/schedules?month=${FEV.month}&year=${FEV.year}`);
+    const allEntries = schedRes.body.entries;
+
+    // Semanas 42h para o DIURNO: sem turno de 6h
+    const week1Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK1);
+    const week2Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK2);
+
+    const sixHourIn42 = [...week1Work, ...week2Work].filter((e) => e.duration_hours === 6);
+    expect(sixHourIn42).toHaveLength(0);
+  });
+});

--- a/backend/src/tests/scheduleRules.test.js
+++ b/backend/src/tests/scheduleRules.test.js
@@ -93,7 +93,7 @@ describe('Regra 13 — sem days_off_per_week, total de horas próximo de 160h', 
 // ─── Regra 4: Emendado válido ────────────────────────────────────────────────
 
 describe('Regra 4 — emendado Tarde→Noturno e Noturno→Manhã são permitidos', () => {
-  it.skip('permite Noturno seguido de Manhã (emendado válido, 18h total) — Manhã disponível após #65', async () => {
+  it('permite Noturno seguido de Manhã (emendado válido, 18h total)', async () => {
     const db = freshDb();
     const emp = createEmployee(db, { name: 'Diego' });
     const noturnoId = shiftId(db, 'Noturno');

--- a/backend/src/tests/shiftTypes.test.js
+++ b/backend/src/tests/shiftTypes.test.js
@@ -6,13 +6,31 @@ import { freshDb } from './helpers.js';
 beforeEach(() => freshDb());
 
 describe('GET /api/shift-types', () => {
-  it('retorna os 2 turnos fixos após seed — Diurno e Noturno', async () => {
+  it('retorna os 4 turnos fixos após seed — Diurno, Noturno, Manhã e Tarde', async () => {
     const res = await request(app).get('/api/shift-types');
     expect(res.status).toBe(200);
-    expect(res.body).toHaveLength(2);
+    expect(res.body).toHaveLength(4);
     const names = res.body.map((s) => s.name);
     expect(names).toContain('Diurno');
     expect(names).toContain('Noturno');
+    expect(names).toContain('Manhã');
+    expect(names).toContain('Tarde');
+  });
+
+  it('Manhã tem horário 07:00–13:00 e 6h de duração', async () => {
+    const res = await request(app).get('/api/shift-types');
+    const manha = res.body.find((s) => s.name === 'Manhã');
+    expect(manha.start_time).toBe('07:00');
+    expect(manha.end_time).toBe('13:00');
+    expect(manha.duration_hours).toBe(6);
+  });
+
+  it('Tarde tem horário 13:00–19:00 e 6h de duração', async () => {
+    const res = await request(app).get('/api/shift-types');
+    const tarde = res.body.find((s) => s.name === 'Tarde');
+    expect(tarde.start_time).toBe('13:00');
+    expect(tarde.end_time).toBe('19:00');
+    expect(tarde.duration_hours).toBe(6);
   });
 
   it('Diurno tem horário 07:00–19:00 e 12h de duração', async () => {


### PR DESCRIPTION
## Resumo

Implementa a regra de turno extra de 6h para motoristas NOTURNO em semanas de 42h (issue #65).

### Mudanças no backend

**database.js**
- : adiciona Manhã (07:00–13:00, 6h, #FCD34D) e Tarde (13:00–19:00, 6h, #F97316) ao seed de DBs novos
- : INSERT OR IGNORE + UPDATE para Manhã e Tarde em DBs existentes

**scheduleGenerator.js**
- : filtra apenas turnos 12h para o  do ciclo normal — impede MANHÃ/TARDE via emendado automático (bug latente com 4 turnos no pool)
- : helper in-memory com emendados (equiv. a , mas sem DB)
- Loop não-ADM:  → adiciona 1 extra 6h (Manhã ou Tarde) a um dia de folga da semana via - Unskip do emendado Noturno→Manhã (agora funcional com Manhã no seed)

### Testes

- : atualizado para 4 turnos fixos (+ Manhã e Tarde)
- : removido  do teste Noturno→Manhã emendado válido
- : 5 novos testes cobrindo os critérios de aceite do #65

### Métricas

**242 testes passando (176 backend + 66 frontend), 0 skipped**

## Critérios de aceite

- [x] Motorista NOTURNO em semana de 36h: apenas turnos de 12h noturno
- [x] Motorista NOTURNO em semana de 42h: 3×12h noturno + 1×6h (Manhã ou Tarde)
- [x] Turno extra de 6h respeita descanso mínimo de 24h (ou emendado Noturno→Manhã válido)
- [x] Motorista DIURNO em semana de 42h: sem turno extra de 6h

Closes #65
