### PR TITLE
feat(#63): ciclo CLT automático via cycle_start_month + cycle_start_year

### DIFF
--- a/backend/src/db/database.js
+++ b/backend/src/db/database.js
@@ -49,7 +49,8 @@ function initSchema() {
       cargo TEXT NOT NULL,
       work_schedule TEXT NOT NULL DEFAULT 'dom_sab',
       color TEXT NOT NULL DEFAULT '#6B7280',
-      cycle_month INTEGER NOT NULL DEFAULT 1,
+      cycle_start_month INTEGER NOT NULL DEFAULT 1,
+      cycle_start_year INTEGER NOT NULL DEFAULT 2026,
       active INTEGER NOT NULL DEFAULT 1,
       created_at TEXT DEFAULT (datetime('now')),
       updated_at TEXT DEFAULT (datetime('now'))
@@ -130,9 +131,22 @@ function runMigrations() {
     db.exec("ALTER TABLE employees ADD COLUMN color TEXT NOT NULL DEFAULT '#6B7280'");
   }
 
-  // Add cycle_month to employees (Issue #41)
-  if (!empCols.includes('cycle_month')) {
-    db.exec('ALTER TABLE employees ADD COLUMN cycle_month INTEGER NOT NULL DEFAULT 1');
+  // Migrate cycle_month → cycle_start_month + cycle_start_year (Issue #63)
+  if (empCols.includes('cycle_month')) {
+    if (!empCols.includes('cycle_start_month')) {
+      db.exec('ALTER TABLE employees ADD COLUMN cycle_start_month INTEGER NOT NULL DEFAULT 1');
+    }
+    if (!empCols.includes('cycle_start_year')) {
+      db.exec('ALTER TABLE employees ADD COLUMN cycle_start_year INTEGER NOT NULL DEFAULT 2026');
+    }
+    db.exec('ALTER TABLE employees DROP COLUMN cycle_month');
+  }
+  // Add cycle_start_month / cycle_start_year to fresh DBs without either column
+  if (!empCols.includes('cycle_month') && !empCols.includes('cycle_start_month')) {
+    db.exec('ALTER TABLE employees ADD COLUMN cycle_start_month INTEGER NOT NULL DEFAULT 1');
+  }
+  if (!empCols.includes('cycle_month') && !empCols.includes('cycle_start_year')) {
+    db.exec('ALTER TABLE employees ADD COLUMN cycle_start_year INTEGER NOT NULL DEFAULT 2026');
   }
 
   // Migrate setor column → employee_sectors table

--- a/backend/src/routes/employees.js
+++ b/backend/src/routes/employees.js
@@ -10,8 +10,8 @@ const SETORES_VALIDOS = [
 ];
 
 const WORK_SCHEDULES_VALIDOS = ['seg_sex', 'dom_sab'];
-const CYCLE_MONTHS_VALIDOS = [1, 2, 3];
 const COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/;
+const MIN_CYCLE_START_YEAR = 2020;
 
 /** Rejeita datas com componentes inválidos (ex: 2025-02-30 rola para março no V8). */
 function isValidCalendarDate(str) {
@@ -106,9 +106,10 @@ router.get('/:id', (req, res) => {
 // ── POST /api/employees ───────────────────────────────────────────────────────
 router.post('/', (req, res) => {
   const db = getDb();
-  const { name, setores, work_schedule = 'dom_sab', color = '#6B7280', cycle_month, restRules } = req.body;
-  // null ou ausente → usar default 1 (gerador usa employee.cycle_month ?? 1)
-  const effectiveCycleMonth = cycle_month ?? 1;
+  const { name, setores, work_schedule = 'dom_sab', color = '#6B7280', cycle_start_month, cycle_start_year, restRules } = req.body;
+  // null ou ausente → usar defaults
+  const effectiveCycleStartMonth = cycle_start_month ?? 1;
+  const effectiveCycleStartYear  = cycle_start_year  ?? 2026;
 
   if (!name) return res.status(400).json({ error: 'name é obrigatório' });
 
@@ -123,14 +124,20 @@ router.post('/', (req, res) => {
     return res.status(400).json({ error: 'color deve ser um hex válido (#RRGGBB)' });
   }
 
-  if (!CYCLE_MONTHS_VALIDOS.includes(Number(effectiveCycleMonth))) {
-    return res.status(400).json({ error: 'cycle_month deve ser 1, 2 ou 3' });
+  const csm = Number(effectiveCycleStartMonth);
+  if (!Number.isInteger(csm) || csm < 1 || csm > 12) {
+    return res.status(400).json({ error: 'cycle_start_month deve ser entre 1 e 12' });
+  }
+
+  const csy = Number(effectiveCycleStartYear);
+  if (!Number.isInteger(csy) || csy < MIN_CYCLE_START_YEAR) {
+    return res.status(400).json({ error: `cycle_start_year deve ser um inteiro >= ${MIN_CYCLE_START_YEAR}` });
   }
 
   const employee = runTransaction(() => {
     const result = db
-      .prepare('INSERT INTO employees (name, cargo, work_schedule, color, cycle_month) VALUES (?, ?, ?, ?, ?)')
-      .run(name.trim(), 'Motorista', work_schedule, color, Number(effectiveCycleMonth));
+      .prepare('INSERT INTO employees (name, cargo, work_schedule, color, cycle_start_month, cycle_start_year) VALUES (?, ?, ?, ?, ?, ?)')
+      .run(name.trim(), 'Motorista', work_schedule, color, csm, csy);
 
     const employeeId = result.lastInsertRowid;
 
@@ -161,7 +168,7 @@ router.post('/', (req, res) => {
 // ── PUT /api/employees/:id ────────────────────────────────────────────────────
 router.put('/:id', (req, res) => {
   const db = getDb();
-  const { name, setores, work_schedule, color, cycle_month, active, restRules } = req.body;
+  const { name, setores, work_schedule, color, cycle_start_month, cycle_start_year, active, restRules } = req.body;
   const id = parseInt(req.params.id);
 
   const employee = db.prepare('SELECT id FROM employees WHERE id = ?').get(id);
@@ -180,8 +187,18 @@ router.put('/:id', (req, res) => {
     return res.status(400).json({ error: 'color deve ser um hex válido (#RRGGBB)' });
   }
 
-  if (cycle_month !== undefined && cycle_month !== null && !CYCLE_MONTHS_VALIDOS.includes(Number(cycle_month))) {
-    return res.status(400).json({ error: 'cycle_month deve ser 1, 2 ou 3' });
+  if (cycle_start_month !== undefined && cycle_start_month !== null) {
+    const csm = Number(cycle_start_month);
+    if (!Number.isInteger(csm) || csm < 1 || csm > 12) {
+      return res.status(400).json({ error: 'cycle_start_month deve ser entre 1 e 12' });
+    }
+  }
+
+  if (cycle_start_year !== undefined && cycle_start_year !== null) {
+    const csy = Number(cycle_start_year);
+    if (!Number.isInteger(csy) || csy < MIN_CYCLE_START_YEAR) {
+      return res.status(400).json({ error: `cycle_start_year deve ser um inteiro >= ${MIN_CYCLE_START_YEAR}` });
+    }
   }
 
   runTransaction(() => {
@@ -192,9 +209,12 @@ router.put('/:id', (req, res) => {
       db.prepare("UPDATE employees SET work_schedule = ?, updated_at = datetime('now') WHERE id = ?").run(work_schedule, id);
     if (color !== undefined)
       db.prepare("UPDATE employees SET color = ?, updated_at = datetime('now') WHERE id = ?").run(color, id);
-    if (cycle_month !== undefined && cycle_month !== null)
-      db.prepare("UPDATE employees SET cycle_month = ?, updated_at = datetime('now') WHERE id = ?")
-        .run(Number(cycle_month), id);
+    if (cycle_start_month !== undefined && cycle_start_month !== null)
+      db.prepare("UPDATE employees SET cycle_start_month = ?, updated_at = datetime('now') WHERE id = ?")
+        .run(Number(cycle_start_month), id);
+    if (cycle_start_year !== undefined && cycle_start_year !== null)
+      db.prepare("UPDATE employees SET cycle_start_year = ?, updated_at = datetime('now') WHERE id = ?")
+        .run(Number(cycle_start_year), id);
     if (active !== undefined)
       db.prepare("UPDATE employees SET active = ?, updated_at = datetime('now') WHERE id = ?").run(active ? 1 : 0, id);
 

--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -33,6 +33,20 @@ export function isValidEmendado(prevShiftName, nextShiftName) {
 }
 
 /**
+ * Calcula a fase do ciclo CLT (1, 2 ou 3) a partir da data de início do ciclo
+ * do motorista e do mês de geração.
+ * @param {number} cycleStartMonth - Mês de início do ciclo (1–12).
+ * @param {number} cycleStartYear  - Ano de início do ciclo.
+ * @param {number} genMonth        - Mês da geração (1–12).
+ * @param {number} genYear         - Ano da geração.
+ * @returns {1|2|3}
+ */
+export function calculateEffectiveCycleMonth(cycleStartMonth, cycleStartYear, genMonth, genYear) {
+  const elapsed = (genYear * 12 + genMonth) - (cycleStartYear * 12 + cycleStartMonth);
+  return ((elapsed % 3) + 3) % 3 + 1;
+}
+
+/**
  * Retorna o label contábil CLT da semana para um motorista.
  * @param {number} cycleMonth - Fase do ciclo do motorista (1, 2 ou 3).
  * @param {number} genMonth   - Mês da geração (1–12).
@@ -47,6 +61,23 @@ export function getWeekType(cycleMonth, genMonth, weekIndex) {
   ];
   const actualCycle = ((genMonth - 1 + cycleMonth - 1) % 3);
   return patterns[actualCycle][Math.min(weekIndex, 3)];
+}
+
+/**
+ * Retorna o label CLT da semana usando a fase direta (sem rotação adicional por genMonth).
+ * Usar em conjunto com calculateEffectiveCycleMonth.
+ * @param {1|2|3} phase    - Fase retornada por calculateEffectiveCycleMonth
+ * @param {number} weekIndex
+ * @returns {'36h' | '42h'}
+ */
+function getWeekTypeFromPhase(phase, weekIndex) {
+  const patterns = [
+    null,
+    ['36h', '42h', '42h', '36h'],  // fase 1
+    ['42h', '42h', '36h', '42h'],  // fase 2
+    ['42h', '36h', '42h', '42h'],  // fase 3
+  ];
+  return patterns[phase][Math.min(weekIndex, 3)];
 }
 
 /**
@@ -107,7 +138,7 @@ export async function generateSchedule({ month, year, overwriteLocked = false })
     const result = runTransaction(() => {
       return generateForEmployee(
         db, employee, shiftTypes, shiftMap, dates,
-        overwriteLocked, warnings, allVacationDates, month
+        overwriteLocked, warnings, allVacationDates, month, year
       );
     });
     results.push(result);
@@ -130,7 +161,7 @@ export async function generateSchedule({ month, year, overwriteLocked = false })
   return { results, warnings };
 }
 
-function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwriteLocked, warnings, allVacationDates, genMonth) {
+function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwriteLocked, warnings, allVacationDates, genMonth, genYear) {
   const rules = db
     .prepare('SELECT * FROM employee_rest_rules WHERE employee_id = ?')
     .get(employee.id) || { min_rest_hours: MIN_REST_HOURS, preferred_shift_id: null };
@@ -176,6 +207,13 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
 
   // Build weekly groups (Sun-based)
   const weeks = buildWeeks(dates);
+
+  // Compute the CLT cycle phase once for this employee/month combination.
+  const effectiveCycleMonth = calculateEffectiveCycleMonth(
+    employee.cycle_start_month ?? 1,
+    employee.cycle_start_year ?? new Date().getFullYear(),
+    genMonth, genYear
+  );
 
   let totalHours = 0;
   let lastShiftEnd = null;
@@ -234,7 +272,7 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
         lastShiftName = null;
       }
 
-      const maxTurnosNaSemana = getWeekType(employee.cycle_month ?? 1, genMonth, wi) === '36h' ? 3 : 4;
+      const maxTurnosNaSemana = getWeekTypeFromPhase(effectiveCycleMonth, wi) === '36h' ? 3 : 4;
       const maxWorkInWeek = Math.min(freeInWeek.length, maxTurnosNaSemana);
       const actualOffInWeek = freeInWeek.length - Math.max(0, maxWorkInWeek);
 
@@ -348,7 +386,7 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
       }
 
       // Issue #65: Motorista NOTURNO em semana de 42h recebe 1 turno extra de 6h (Manhã ou Tarde).
-      if (isNoturno && getWeekType(employee.cycle_month ?? 1, genMonth, wi) === '42h') {
+      if (isNoturno && getWeekTypeFromPhase(effectiveCycleMonth, wi) === '42h') {
         const extraCandidates = [manhaShift, tardeShift].filter(Boolean);
         let extraAdded = false;
 
@@ -407,7 +445,7 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
 
   const weekClassifications = weeks.map((_, wi) => ({
     weekIndex: wi,
-    type: getWeekType(employee.cycle_month ?? 1, genMonth, wi),
+    type: getWeekTypeFromPhase(effectiveCycleMonth, wi),
   }));
 
   return { employee: employee.name, hours: finalHours, weekClassifications };

--- a/backend/src/tests/cycleMonth.test.js
+++ b/backend/src/tests/cycleMonth.test.js
@@ -1,10 +1,10 @@
 /**
- * test(generator): cobertura de integração do ciclo CLT (cycle_month) — issue #45
+ * test(generator): cobertura de integração do ciclo CLT (cycle_start_month + cycle_start_year)
  *
  * Tester Senior
  *
- * Testa o gerador de ponta a ponta com cycle_month variando.
- * Não testa getWeekType diretamente (já coberto em scheduleGenerator.unit.test.js).
+ * Testa o gerador de ponta a ponta com cycle_start_month/year variando.
+ * Não testa calculateEffectiveCycleMonth diretamente (coberto em scheduleGenerator.unit.test.js).
  *
  * Referência de calendário — Fevereiro 2025 (28 dias):
  *   Feb 1  = Sábado   → Semana 0: [Feb 1]  (1 dia)
@@ -13,10 +13,10 @@
  *   Feb 16 = Domingo  → Semana 3: [Feb 16–22] (7 dias)
  *   Feb 23 = Domingo  → Semana 4: [Feb 23–28] (6 dias)
  *
- * getWeekType(cycleMonth, genMonth=2, weekIndex):
- *   cycle_month=1 → actualCycle=1 → patterns[1]=['42h','42h','36h','42h']
+ * calculateEffectiveCycleMonth + getWeekTypeFromPhase (genMonth=2/year=2025):
+ *   cycle_start=Jan/2025 (elapsed=1) → phase=2 → patterns[2]=['42h','42h','36h','42h']
  *     semana 1 = 42h (4 ADM turnos), semana 2 = 36h (3 ADM turnos)
- *   cycle_month=2 → actualCycle=2 → patterns[2]=['42h','36h','42h','42h']
+ *   cycle_start=Dez/2024 (elapsed=2) → phase=3 → patterns[3]=['42h','36h','42h','42h']
  *     semana 1 = 36h (3 ADM turnos), semana 2 = 42h (4 ADM turnos)
  *
  * Notas de design dos cenários ADM:
@@ -24,10 +24,10 @@
  *   consecutivos — abaixo do mínimo de 24h. O gerador cai back para Noturno/Manhã
  *   em dias seguidos. Isso resulta em totais variáveis entre 144h–160h por mês.
  *
- *   cycle_month=2 em Fev/2025 gera exatamente 160h → atinge COVERAGE_HOURS_CAP →
+ *   cycle_start=Dez/2024 em Fev/2025 gera exatamente 160h → atinge COVERAGE_HOURS_CAP →
  *   enforcement não o altera. Os contadores por semana são determinísticos.
  *
- *   cycle_month=1 em Fev/2025 gera 154h → abaixo do cap. O enforceDailyCoverage
+ *   cycle_start=Jan/2025 em Fev/2025 gera 154h → abaixo do cap. O enforceDailyCoverage
  *   adiciona 1 turno à semana 1 (forçado) → semana 2 (36h) permanece intacta.
  */
 
@@ -63,16 +63,23 @@ function totalHoursOf(entries, empId) {
 beforeEach(() => freshDb());
 
 // ── Cenário A ─────────────────────────────────────────────────────────────────
-// Não-ADM (Ambulância): cycle_month é apenas label contábil CLT — não afeta
+// Não-ADM (Ambulância): cycle_start é apenas label contábil CLT — não afeta
 // o número de plantões físicos. Todos os valores devem produzir a mesma faixa
 // de horas (144h–180h, desvio ≤ 12h de 160h).
 
-describe('Cenário A — Não-ADM: cycle_month não afeta plantões físicos', () => {
-  for (const cycleMonth of [1, 2, 3]) {
-    it(`Ambulância cycle_month=${cycleMonth} em Janeiro/2025: horas entre 144h e 180h, desvio ≤ 12h`, async () => {
+// cycle_start combos que produzem fases 1, 2, 3 para Jan/2025
+const CYCLE_START_JAN2025 = [
+  { cycle_start_month: 1, cycle_start_year: 2025 },  // elapsed=0 → phase 1
+  { cycle_start_month: 12, cycle_start_year: 2024 }, // elapsed=1 → phase 2
+  { cycle_start_month: 11, cycle_start_year: 2024 }, // elapsed=2 → phase 3
+];
+
+describe('Cenário A — Não-ADM: cycle_start não afeta plantões físicos', () => {
+  for (const { cycle_start_month, cycle_start_year } of CYCLE_START_JAN2025) {
+    it(`Ambulância cycle_start=${cycle_start_month}/${cycle_start_year} em Janeiro/2025: horas entre 144h e 180h, desvio ≤ 12h`, async () => {
       const empRes = await request(app)
         .post('/api/employees')
-        .send({ name: `Motorista A${cycleMonth}`, setores: ['Transporte Ambulância'], cycle_month: cycleMonth });
+        .send({ name: `Motorista A${cycle_start_month}`, setores: ['Transporte Ambulância'], cycle_start_month, cycle_start_year });
       expect(empRes.status).toBe(201);
 
       const genRes = await request(app)
@@ -96,19 +103,21 @@ describe('Cenário A — Não-ADM: cycle_month não afeta plantões físicos', (
 });
 
 // ── Cenário B ─────────────────────────────────────────────────────────────────
-// ADM (Transporte Administrativo): cycle_month determina semanas 36h (3 turnos)
+// ADM (Transporte Administrativo): cycle_start determina semanas 36h (3 turnos)
 // vs 42h (4 turnos).
 //
-// cycle_month=2: com turnos de 12h (Diurno), total bruto > 160h → correctHours remove
+// cycle_start=Dez/2024 (phase 3 em Fev/2025): sem 1=36h (3 base), sem 2=42h (4 base).
+//   Com turnos de 12h (Diurno), total bruto > 160h → correctHours remove
 //   1 plantão da semana 2 → semana 1 = 4 (36h base + 1 enforcement), semana 2 = 3.
 //
-// cycle_month=1: total 154h → enforcement adiciona 1 turno na semana 1 (Feb 6) →
+// cycle_start=Jan/2025 (phase 2 em Fev/2025): sem 1=42h (4 base), sem 2=36h (3 turnos).
+//   Total 154h → enforcement adiciona 1 turno na semana 1 (Feb 6) →
 //   semana 1 cresce, mas semana 2 (36h, 3 turnos) permanece intacta pois após
 //   a adição o cap é atingido e enforcement para.
 
 describe('Cenário B — ADM: label CLT (36h/42h) afeta número de turnos por semana', () => {
-  it('ADM cycle_month=2: semana 1 de Fev/2025 (36h label) tem 4 plantões (enforcement); semana 2 (42h label) tem 3 plantões (correctHours remove 1)', async () => {
-    // cycle_month=2 → actualCycle=2 → patterns[2]=['42h','36h','42h','42h']
+  it('ADM cycle_start=Dez/2024 (phase 3): semana 1 de Fev/2025 (36h label) tem 4 plantões (enforcement); semana 2 (42h label) tem 3 plantões (correctHours remove 1)', async () => {
+    // cycle_start=Dez/2024 → phase 3 → patterns[3]=['42h','36h','42h','42h']
     // sem 1=36h (3 turnos base), sem 2=42h (4 turnos base).
     //
     // Com turnos de 12h (Diurno — #64), o total bruto em Fev é > 160h → correctHours
@@ -117,7 +126,7 @@ describe('Cenário B — ADM: label CLT (36h/42h) afeta número de turnos por se
     // Cap de 168h atingido após enforcement → sem alterações adicionais.
     const empRes = await request(app)
       .post('/api/employees')
-      .send({ name: 'ADM Ciclo2', setores: ['Transporte Administrativo'], cycle_month: 2 });
+      .send({ name: 'ADM Phase3', setores: ['Transporte Administrativo'], cycle_start_month: 12, cycle_start_year: 2024 });
     expect(empRes.status).toBe(201);
 
     const genRes = await request(app).post('/api/schedules/generate').send(FEV);
@@ -133,13 +142,13 @@ describe('Cenário B — ADM: label CLT (36h/42h) afeta número de turnos por se
     expect(workIn(entries, empId, FEV_WEEK2)).toBe(3);
   });
 
-  it('ADM cycle_month=1: semana 2 de Fev/2025 tem label 36h → exatamente 3 plantões; semana 1 (42h) tem mais plantões que semana 2 (36h)', async () => {
-    // cycle_month=1 → actualCycle=1 → patterns[1]=['42h','42h','36h','42h']
+  it('ADM cycle_start=Jan/2025 (phase 2): semana 2 de Fev/2025 tem label 36h → exatamente 3 plantões; semana 1 (42h) tem mais plantões que semana 2 (36h)', async () => {
+    // cycle_start=Jan/2025 → phase 2 → patterns[2]=['42h','42h','36h','42h']
     // sem 1=42h (4 turnos base), sem 2=36h (3 turnos). Total gerado=154h → enforcement
     // adiciona 1 turno forçado na sem 1 (Feb 6, cap atingido) → sem 2 permanece em 3.
     const empRes = await request(app)
       .post('/api/employees')
-      .send({ name: 'ADM Ciclo1', setores: ['Transporte Administrativo'], cycle_month: 1 });
+      .send({ name: 'ADM Phase2', setores: ['Transporte Administrativo'], cycle_start_month: 1, cycle_start_year: 2025 });
     expect(empRes.status).toBe(201);
 
     const genRes = await request(app).post('/api/schedules/generate').send(FEV);
@@ -160,7 +169,7 @@ describe('Cenário B — ADM: label CLT (36h/42h) afeta número de turnos por se
 });
 
 // ── Cenário C ─────────────────────────────────────────────────────────────────
-// seg_sex + cycle_month: Sáb/Dom são folga obrigatória do gerador. O Passo 3
+// seg_sex + cycle_start: Sáb/Dom são folga obrigatória do gerador. O Passo 3
 // (emergência) do enforcement pode forçar um plantão em Sábado quando não há
 // outra opção, mas Domingos permanecem sempre livres (cap atingido após o Sábado).
 //
@@ -168,8 +177,8 @@ describe('Cenário B — ADM: label CLT (36h/42h) afeta número de turnos por se
 //   - Nenhum plantão em Domingo (Sunday) — protegido pelo cap pós-enforcement
 //   - Total de horas dentro de ±12h do alvo de 160h
 
-describe('Cenário C — seg_sex + cycle_month: interação não testada', () => {
-  it('ADM seg_sex cycle_month=2 em Fev/2025: no máximo 1 plantão em Domingo e horas dentro de ±12h do alvo', async () => {
+describe('Cenário C — seg_sex + cycle_start: interação não testada', () => {
+  it('ADM seg_sex cycle_start=Dez/2024 (phase 3) em Fev/2025: no máximo 1 plantão em Domingo e horas dentro de ±12h do alvo', async () => {
     // Com a distribuição de folgas por employee.id (fix #55), a semana 1 aloca
     // plantões em Seg–Qua em vez de Seg–Sex do código anterior. Isso muda quais
     // dias livres têm descanso adequado para correctHours, que neste cenário
@@ -184,10 +193,11 @@ describe('Cenário C — seg_sex + cycle_month: interação não testada', () =>
     const empRes = await request(app)
       .post('/api/employees')
       .send({
-        name: 'ADM SegSex Ciclo2',
+        name: 'ADM SegSex Phase3',
         setores: ['Transporte Administrativo'],
         work_schedule: 'seg_sex',
-        cycle_month: 2,
+        cycle_start_month: 12,
+        cycle_start_year: 2024,
       });
     expect(empRes.status).toBe(201);
 
@@ -215,17 +225,18 @@ describe('Cenário C — seg_sex + cycle_month: interação não testada', () =>
     expect(Math.abs(finalHours - 160)).toBeLessThanOrEqual(12);
   });
 
-  it('ADM seg_sex cycle_month=2: semana 1 aloca plantões em dias úteis (redução de disponibilidade refletida)', async () => {
-    // Com seg_sex + 36h (cycle_month=2 em Fev), a semana 1 tem no máximo
+  it('ADM seg_sex cycle_start=Dez/2024 (phase 3): semana 1 aloca plantões em dias úteis (redução de disponibilidade refletida)', async () => {
+    // Com seg_sex + 36h (phase 3 em Fev), a semana 1 tem no máximo
     // 5 dias úteis disponíveis (Seg–Sex). A geração tenta 3 turnos nesses dias.
     // correctHours pode adicionar mais 1, totalizando ≤ 5 (limite de úteis).
     const empRes = await request(app)
       .post('/api/employees')
       .send({
-        name: 'ADM SegSex Ciclo2 B',
+        name: 'ADM SegSex Phase3 B',
         setores: ['Transporte Administrativo'],
         work_schedule: 'seg_sex',
-        cycle_month: 2,
+        cycle_start_month: 12,
+        cycle_start_year: 2024,
       });
     expect(empRes.status).toBe(201);
 
@@ -243,19 +254,19 @@ describe('Cenário C — seg_sex + cycle_month: interação não testada', () =>
 });
 
 // ── Cenário D1 ────────────────────────────────────────────────────────────────
-// Labels distintas: dois motoristas ADM com cycle_month diferentes no mesmo mês
+// Labels distintas: dois motoristas ADM com cycle_start diferentes no mesmo mês
 // devem ter distribuições semanais diferentes na semana 2:
-//   cycle_month=1 → semana 2 = 36h → 3 plantões (enforcement parado, sem 2 intacta)
-//   cycle_month=2 → semana 2 = 42h → 4 plantões (cap atingido, sem enforcement)
+//   cycle_start=Jan/2025 (phase 2) → semana 2 = 36h → 3 plantões (enforcement parado)
+//   cycle_start=Dez/2024 (phase 3) → semana 2 = 42h → 4 plantões (cap atingido)
 
-describe('Cenário D1 — labels: weekClassifications distintas entre cycle_month diferentes', () => {
-  it('ADM cycle_month=1 e cycle_month=2 no mesmo mês: contagem de plantões na semana 2 difere entre eles', async () => {
+describe('Cenário D1 — labels: weekClassifications distintas entre cycle_start diferentes', () => {
+  it('ADM cycle_start=Jan/2025 (phase 2) e cycle_start=Dez/2024 (phase 3) no mesmo mês: contagem de plantões na semana 2 difere', async () => {
     const emp1Res = await request(app)
       .post('/api/employees')
-      .send({ name: 'ADM Fase1', setores: ['Transporte Administrativo'], cycle_month: 1 });
+      .send({ name: 'ADM Phase2', setores: ['Transporte Administrativo'], cycle_start_month: 1, cycle_start_year: 2025 });
     const emp2Res = await request(app)
       .post('/api/employees')
-      .send({ name: 'ADM Fase2', setores: ['Transporte Administrativo'], cycle_month: 2 });
+      .send({ name: 'ADM Phase3', setores: ['Transporte Administrativo'], cycle_start_month: 12, cycle_start_year: 2024 });
     expect(emp1Res.status).toBe(201);
     expect(emp2Res.status).toBe(201);
 
@@ -265,12 +276,12 @@ describe('Cenário D1 — labels: weekClassifications distintas entre cycle_mont
     const schedRes = await request(app).get(`/api/schedules?month=${FEV.month}&year=${FEV.year}`);
     const entries = schedRes.body.entries;
 
-    // cycle_month=1 → sem 2 = 36h → 3 plantões (enforcement parado no cap)
+    // phase 2 → sem 2 = 36h → 3 plantões (enforcement parado no cap)
     const week2Emp1 = workIn(entries, emp1Res.body.id, FEV_WEEK2);
-    // cycle_month=2 → sem 2 = 42h → 4 plantões (cap atingido desde a geração)
+    // phase 3 → sem 2 = 42h → 4 plantões (cap atingido desde a geração)
     const week2Emp2 = workIn(entries, emp2Res.body.id, FEV_WEEK2);
 
-    // As distribuições devem diferir — prova que cycle_month afeta o scheduling ADM
+    // As distribuições devem diferir — prova que cycle_start afeta o scheduling ADM
     expect(week2Emp1).not.toBe(week2Emp2);
     expect(week2Emp1).toBe(3); // 36h
     expect(week2Emp2).toBe(4); // 42h
@@ -278,18 +289,18 @@ describe('Cenário D1 — labels: weekClassifications distintas entre cycle_mont
 });
 
 // ── Cenário D2 ────────────────────────────────────────────────────────────────
-// Cobertura mantida: motoristas de Hemodiálise e Ambulância com cycle_month
+// Cobertura mantida: motoristas de Hemodiálise e Ambulância com cycle_start
 // distintos. O gerador deve completar sem crash; cobertura diurna (Regra 16)
 // e noturna (Regras 21/22) deve ser satisfeita ou emitir warnings corretos.
 
-describe('Cenário D2 — cobertura: cobertura diurna/noturna com cycle_month distintos', () => {
-  it('Hemodiálise cycle_month=1 + Ambulância cycle_month=2: geração completa com results válidos e warnings estruturados', async () => {
+describe('Cenário D2 — cobertura: cobertura diurna/noturna com cycle_start distintos', () => {
+  it('Hemodiálise cycle_start=Jan/2025 (phase 2) + Ambulância cycle_start=Dez/2024 (phase 3): geração completa com results válidos e warnings estruturados', async () => {
     const hemoRes = await request(app)
       .post('/api/employees')
-      .send({ name: 'Hemo Ciclo1', setores: ['Transporte Hemodiálise'], cycle_month: 1 });
+      .send({ name: 'Hemo Phase2', setores: ['Transporte Hemodiálise'], cycle_start_month: 1, cycle_start_year: 2025 });
     const ambulRes = await request(app)
       .post('/api/employees')
-      .send({ name: 'Ambul Ciclo2', setores: ['Transporte Ambulância'], cycle_month: 2 });
+      .send({ name: 'Ambul Phase3', setores: ['Transporte Ambulância'], cycle_start_month: 12, cycle_start_year: 2024 });
     expect(hemoRes.status).toBe(201);
     expect(ambulRes.status).toBe(201);
 

--- a/backend/src/tests/employees.test.js
+++ b/backend/src/tests/employees.test.js
@@ -156,91 +156,115 @@ describe('DELETE /api/employees/:id', () => {
   });
 });
 
-describe('cycle_month — POST/PUT validação', () => {
-  it('aceita cycle_month válido (1, 2, 3)', async () => {
-    for (const cm of [1, 2, 3]) {
-      const db = freshDb();
+describe('cycle_start — POST/PUT validação', () => {
+  it('aceita cycle_start_month válido (1-12) no POST', async () => {
+    for (const csm of [1, 6, 12]) {
+      freshDb();
       const res = await request(app).post('/api/employees').send({
-        name: `Motorista Ciclo ${cm}`,
+        name: `Motorista Mês ${csm}`,
         setores: ['Transporte Ambulância'],
-        cycle_month: cm,
+        cycle_start_month: csm,
+        cycle_start_year: 2025,
       });
       expect(res.status).toBe(201);
-      expect(res.body.cycle_month).toBe(cm);
+      expect(res.body.cycle_start_month).toBe(csm);
+      expect(res.body.cycle_start_year).toBe(2025);
       resetDb();
     }
   });
 
-  it('rejeita cycle_month inválido no POST', async () => {
-    for (const cm of [0, 4, 'invalido', 1.5]) {
+  it('rejeita cycle_start_month inválido no POST (0, 13, string, 1.5)', async () => {
+    for (const csm of [0, 13, 'invalido', 1.5]) {
       freshDb();
       const res = await request(app).post('/api/employees').send({
         name: 'Teste',
         setores: ['Transporte Ambulância'],
-        cycle_month: cm,
+        cycle_start_month: csm,
+        cycle_start_year: 2025,
       });
       expect(res.status).toBe(400);
-      expect(res.body.error).toMatch(/cycle_month/);
+      expect(res.body.error).toMatch(/cycle_start_month/);
       resetDb();
     }
   });
 
-  it('cycle_month default é 1 quando não fornecido', async () => {
+  it('rejeita cycle_start_year < 2020 no POST', async () => {
+    freshDb();
+    const res = await request(app).post('/api/employees').send({
+      name: 'Teste',
+      setores: ['Transporte Ambulância'],
+      cycle_start_month: 1,
+      cycle_start_year: 2019,
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/cycle_start_year/);
+    resetDb();
+  });
+
+  it('defaults de cycle_start são 1 e 2026 quando não fornecidos', async () => {
     freshDb();
     const res = await request(app).post('/api/employees').send({
       name: 'Sem Ciclo',
       setores: ['Transporte Ambulância'],
     });
     expect(res.status).toBe(201);
-    expect(res.body.cycle_month).toBe(1);
+    expect(res.body.cycle_start_month).toBe(1);
+    expect(res.body.cycle_start_year).toBe(2026);
     resetDb();
   });
 
-  it('atualiza cycle_month via PUT', async () => {
+  it('atualiza cycle_start_month e cycle_start_year via PUT', async () => {
     const db = freshDb();
     const emp = createEmployee(db, { name: 'Ciclo Update', setor: 'Transporte Ambulância' });
-    const res = await request(app).put(`/api/employees/${emp.id}`).send({ cycle_month: 3 });
+    const res = await request(app).put(`/api/employees/${emp.id}`).send({
+      cycle_start_month: 6,
+      cycle_start_year: 2024,
+    });
     expect(res.status).toBe(200);
-    expect(res.body.cycle_month).toBe(3);
+    expect(res.body.cycle_start_month).toBe(6);
+    expect(res.body.cycle_start_year).toBe(2024);
     resetDb();
   });
 
-  it('rejeita cycle_month inválido no PUT', async () => {
+  it('rejeita cycle_start_month inválido no PUT', async () => {
     const db = freshDb();
     const emp = createEmployee(db, { name: 'Ciclo Inválido', setor: 'Transporte Ambulância' });
-    const res = await request(app).put(`/api/employees/${emp.id}`).send({ cycle_month: 5 });
+    const res = await request(app).put(`/api/employees/${emp.id}`).send({ cycle_start_month: 15 });
     expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/cycle_start_month/);
     resetDb();
   });
 
-  it('aceita cycle_month null no POST — armazena default 1', async () => {
-    freshDb();
-    const res = await request(app).post('/api/employees').send({
-      name: 'Ciclo Null',
-      setores: ['Transporte Ambulância'],
-      cycle_month: null,
-    });
-    expect(res.status).toBe(201);
-    expect(res.body.cycle_month).toBe(1);
-    resetDb();
-  });
-
-  it('aceita cycle_month null no PUT — no-op, mantém valor atual', async () => {
+  it('aceita cycle_start_month null no PUT — no-op, mantém valor atual', async () => {
     const db = freshDb();
     const emp = createEmployee(db, { name: 'Ciclo Reset', setor: 'Transporte Ambulância' });
-    // createEmployee não define cycle_month → default do DB é 1
-    const res = await request(app).put(`/api/employees/${emp.id}`).send({ cycle_month: null });
+    // createEmployee usa defaults do DB: cycle_start_month=1, cycle_start_year=2026
+    const res = await request(app).put(`/api/employees/${emp.id}`).send({ cycle_start_month: null });
     expect(res.status).toBe(200);
-    expect(res.body.cycle_month).toBe(1);
+    expect(res.body.cycle_start_month).toBe(1);
     resetDb();
   });
 
-  it('rejeita cycle_month 99 no PUT', async () => {
-    const db = freshDb();
-    const emp = createEmployee(db, { name: 'Ciclo 99', setor: 'Transporte Ambulância' });
-    const res = await request(app).put(`/api/employees/${emp.id}`).send({ cycle_month: 99 });
-    expect(res.status).toBe(400);
-    expect(res.body.error).toMatch(/cycle_month/);
+  it('dois motoristas com cycle_start diferentes geram ciclos diferentes no mesmo mês', async () => {
+    freshDb();
+    // Motorista A: cycle_start=Jan/2026 → ciclo 1 em Jan/2026, ciclo 2 em Fev/2026
+    const resA = await request(app).post('/api/employees').send({
+      name: 'Motorista A',
+      setores: ['Transporte Ambulância'],
+      cycle_start_month: 1,
+      cycle_start_year: 2026,
+    });
+    // Motorista B: cycle_start=Dez/2025 → ciclo 2 em Jan/2026, ciclo 3 em Fev/2026
+    const resB = await request(app).post('/api/employees').send({
+      name: 'Motorista B',
+      setores: ['Transporte Ambulância'],
+      cycle_start_month: 12,
+      cycle_start_year: 2025,
+    });
+    expect(resA.status).toBe(201);
+    expect(resB.status).toBe(201);
+    // Ciclos distintos: A.start ≠ B.start → computeCycleMonth diferente para genMonth=Jan/2026
+    expect(resA.body.cycle_start_month).not.toBe(resB.body.cycle_start_month);
     resetDb();
   });
 });

--- a/backend/src/tests/noturno42h.test.js
+++ b/backend/src/tests/noturno42h.test.js
@@ -11,16 +11,17 @@
  *
  * Calendário de referência — Fevereiro 2025 (28 dias):
  *   Feb 1 = Sábado → Semana 0: [Feb 1]
- *   Feb 2 = Domingo → Semana 1: [Feb 2–8]   (42h com cycle_month=3)
- *   Feb 9 = Domingo → Semana 2: [Feb 9–15]  (42h com cycle_month=3)
- *   Feb 16 = Domingo → Semana 3: [Feb 16–22] (36h com cycle_month=3)
- *   Feb 23 = Domingo → Semana 4: [Feb 23–28] (36h com cycle_month=3)
+ *   Feb 2 = Domingo → Semana 1: [Feb 2–8]   (42h com cycle_start=Fev/2025)
+ *   Feb 9 = Domingo → Semana 2: [Feb 9–15]  (42h com cycle_start=Fev/2025)
+ *   Feb 16 = Domingo → Semana 3: [Feb 16–22] (36h com cycle_start=Fev/2025)
+ *   Feb 23 = Domingo → Semana 4: [Feb 23–28] (36h com cycle_start=Fev/2025)
  *
- * getWeekType(3, 2, wi):
- *   actualCycle = (1 + 2) % 3 = 0 → patterns[0] = ['36h','42h','42h','36h']
+ * calculateEffectiveCycleMonth(2, 2025, 2, 2025) → elapsed=0 → phase=1
+ * getWeekTypeFromPhase(1, wi) → patterns[1] = ['36h','42h','42h','36h']
  *   wi=0 → 36h, wi=1 → 42h, wi=2 → 42h, wi=3 → 36h, wi=4 → 36h (clamped)
+ * (idêntico ao antigo getWeekType(3, 2, wi) → actualCycle=0 → patterns[0])
  *
- * Total esperado com cycle_month=3 em Feb/2025 (motorista NOTURNO):
+ * Total esperado com cycle_start=Fev/2025 em Feb/2025 (motorista NOTURNO):
  *   Semana 0 (1 dia): 0 plantões (1 dia livre → min 1 folga → 0 trabalho)
  *   Semanas 1 e 2 (42h): 3 × 12h + 1 × 6h = 42h cada
  *   Semanas 3 e 4 (36h): 3 × 12h = 36h cada
@@ -52,8 +53,13 @@ function workEntriesInWeek(allEntries, empId, weekDates) {
   return entriesInWeek(allEntries, empId, weekDates).filter((e) => !e.is_day_off);
 }
 
-/** Cria motorista via API com preferred_shift por nome */
-async function createNoturnoEmployee(name, cycleMonth = 3) {
+/**
+ * Cria motorista via API com preferred_shift por nome.
+ * cycle_start padrão: Fev/2025 → elapsed=0 → phase=1 para Fev/2025
+ * (equivale ao antigo cycle_month=3 para genMonth=2: actualCycle=0 → patterns[0]=['36h','42h','42h','36h'])
+ * getWeekTypeFromPhase(1,wi) = patterns[1]=['36h','42h','42h','36h'] — padrão idêntico.
+ */
+async function createNoturnoEmployee(name, cycleStartMonth = 2, cycleStartYear = 2025) {
   // Busca o id do turno Noturno a partir da lista de shift-types
   const shiftsRes = await request(app).get('/api/shift-types');
   const noturnoId = shiftsRes.body.find((s) => s.name === 'Noturno')?.id;
@@ -62,14 +68,15 @@ async function createNoturnoEmployee(name, cycleMonth = 3) {
   const empRes = await request(app).post('/api/employees').send({
     name,
     setores: ['Transporte Ambulância'],
-    cycle_month: cycleMonth,
+    cycle_start_month: cycleStartMonth,
+    cycle_start_year: cycleStartYear,
     restRules: { preferred_shift_id: noturnoId, notes: null },
   });
   expect(empRes.status).toBe(201);
   return { emp: empRes.body, noturnoId };
 }
 
-async function createDiurnoEmployee(name, cycleMonth = 3) {
+async function createDiurnoEmployee(name, cycleStartMonth = 2, cycleStartYear = 2025) {
   const shiftsRes = await request(app).get('/api/shift-types');
   const diurnoId = shiftsRes.body.find((s) => s.name === 'Diurno')?.id;
   expect(diurnoId).toBeDefined();
@@ -77,7 +84,8 @@ async function createDiurnoEmployee(name, cycleMonth = 3) {
   const empRes = await request(app).post('/api/employees').send({
     name,
     setores: ['Transporte Ambulância'],
-    cycle_month: cycleMonth,
+    cycle_start_month: cycleStartMonth,
+    cycle_start_year: cycleStartYear,
     restRules: { preferred_shift_id: diurnoId, notes: null },
   });
   expect(empRes.status).toBe(201);

--- a/backend/src/tests/scheduleGenerator.unit.test.js
+++ b/backend/src/tests/scheduleGenerator.unit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { isValidEmendado, correctHours, enforceDailyCoverage, getWeekType } from '../services/scheduleGenerator.js';
+import { isValidEmendado, correctHours, enforceDailyCoverage, getWeekType, calculateEffectiveCycleMonth } from '../services/scheduleGenerator.js';
 import { freshDb, createEmployee } from './helpers.js';
 
 describe('isValidEmendado', () => {
@@ -366,6 +366,35 @@ describe('enforceDailyCoverage', () => {
     expect(getEntry(db, emp2.id, '2025-01-08').is_day_off).toBe(1); // Marta em férias intocada
     expect(warnings.some(w => w.type === 'cobertura_minima_insuficiente' && w.date === '2025-01-08')).toBe(true);
     expect(warnings.some(w => w.type === 'sem_motorista')).toBe(false);
+  });
+});
+
+describe('calculateEffectiveCycleMonth', () => {
+  it('mês de início: retorna fase 1', () => {
+    expect(calculateEffectiveCycleMonth(1, 2026, 1, 2026)).toBe(1);
+    expect(calculateEffectiveCycleMonth(3, 2026, 3, 2026)).toBe(1);
+  });
+
+  it('1 mês depois: retorna fase 2', () => {
+    expect(calculateEffectiveCycleMonth(1, 2026, 2, 2026)).toBe(2);
+  });
+
+  it('2 meses depois: retorna fase 3', () => {
+    expect(calculateEffectiveCycleMonth(1, 2026, 3, 2026)).toBe(3);
+  });
+
+  it('3 meses depois: retorna fase 1 (reinicia)', () => {
+    expect(calculateEffectiveCycleMonth(1, 2026, 4, 2026)).toBe(1);
+  });
+
+  it('12 meses depois (1 ano): retorna fase 1', () => {
+    expect(calculateEffectiveCycleMonth(1, 2026, 1, 2027)).toBe(1);
+  });
+
+  it('dois motoristas com cycle_start diferentes → fases distintas no mesmo mês', () => {
+    // Jan/2026: A(start=Jan/2026)=fase1, B(start=Dez/2025)=fase2
+    expect(calculateEffectiveCycleMonth(1, 2026, 1, 2026)).toBe(1);
+    expect(calculateEffectiveCycleMonth(12, 2025, 1, 2026)).toBe(2);
   });
 });
 

--- a/frontend/src/components/employees/EmployeeForm.jsx
+++ b/frontend/src/components/employees/EmployeeForm.jsx
@@ -24,6 +24,8 @@ export default function EmployeeForm({ open, onOpenChange, employee, onSuccess }
 
   const isEdit = Boolean(employee);
 
+  const now = new Date();
+
   const {
     register,
     handleSubmit,
@@ -34,7 +36,8 @@ export default function EmployeeForm({ open, onOpenChange, employee, onSuccess }
       name: '',
       work_schedule: 'dom_sab',
       color: '#6B7280',
-      cycle_month: '1',
+      cycle_start_month: String(now.getMonth() + 1),
+      cycle_start_year: String(now.getFullYear()),
       preferred_shift_id: '',
       notes: '',
     },
@@ -47,11 +50,13 @@ export default function EmployeeForm({ open, onOpenChange, employee, onSuccess }
 
   useEffect(() => {
     if (open) {
+      const resetNow = new Date();
       reset({
         name: employee?.name ?? '',
         work_schedule: employee?.work_schedule ?? 'dom_sab',
         color: employee?.color ?? '#6B7280',
-        cycle_month: String(employee?.cycle_month ?? 1),
+        cycle_start_month: String(employee?.cycle_start_month ?? (resetNow.getMonth() + 1)),
+        cycle_start_year: String(employee?.cycle_start_year ?? resetNow.getFullYear()),
         preferred_shift_id: employee?.restRules?.preferred_shift_id != null
           ? String(employee.restRules.preferred_shift_id)
           : '',
@@ -115,7 +120,8 @@ export default function EmployeeForm({ open, onOpenChange, employee, onSuccess }
         setores: selectedSetores,
         work_schedule: data.work_schedule,
         color: data.color,
-        cycle_month: parseInt(data.cycle_month),
+        cycle_start_month: parseInt(data.cycle_start_month),
+        cycle_start_year: parseInt(data.cycle_start_year),
         restRules: {
           preferred_shift_id: data.preferred_shift_id ? parseInt(data.preferred_shift_id) : null,
           notes: data.notes || null,
@@ -196,16 +202,33 @@ export default function EmployeeForm({ open, onOpenChange, employee, onSuccess }
               </div>
             </div>
 
-            {/* Ciclo CLT */}
+            {/* Ciclo CLT — início */}
             <div>
-              <label className="label">Ciclo CLT</label>
-              <select className="input" {...register('cycle_month')}>
-                <option value="1">Mês 1 — 36/42/42/36h</option>
-                <option value="2">Mês 2 — 42/42/36/42h</option>
-                <option value="3">Mês 3 — 42/36/42/42h</option>
-              </select>
+              <label className="label">Início do ciclo CLT</label>
+              <div className="grid grid-cols-2 gap-2 mt-1">
+                <div>
+                  <label className="text-xs text-gray-500 mb-1 block">Mês</label>
+                  <select className="input" {...register('cycle_start_month', { required: true })}>
+                    {[
+                      'Janeiro','Fevereiro','Março','Abril','Maio','Junho',
+                      'Julho','Agosto','Setembro','Outubro','Novembro','Dezembro',
+                    ].map((m, i) => (
+                      <option key={i + 1} value={String(i + 1)}>{m}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="text-xs text-gray-500 mb-1 block">Ano</label>
+                  <input
+                    type="number"
+                    className="input"
+                    min="2020"
+                    {...register('cycle_start_year', { required: true, min: 2020 })}
+                  />
+                </div>
+              </div>
               <p className="text-xs text-gray-400 mt-1">
-                Define a fase do ciclo de 3 meses (média 40h/sem pela CLT)
+                Data de início do ciclo de 3 meses (média 40h/sem pela CLT)
               </p>
             </div>
 


### PR DESCRIPTION
## Summary

- Substitui `cycle_month` (1/2/3) por `cycle_start_month` + `cycle_start_year` — gerador calcula fase CLT automaticamente para qualquer mês de geração
- Corrige bug de double-count de `genMonth` no gerador: adiciona `getWeekTypeFromPhase(phase, wi)` que recebe a fase direta sem rotação adicional por genMonth
- Migration DROP `cycle_month` + ADD `cycle_start_month/year` para DBs existentes
- Frontend: seletor mês + campo ano substituem o select de 3 opções
- 182 testes backend + 66 testes frontend passando

## Test plan
- [x] `npm test` raiz: 182 backend + 66 frontend passando (0 falhas)
- [x] `calculateEffectiveCycleMonth`: 6 novos testes unitários
- [x] `cycleMonth.test.js`: migrado para cycle_start_month/year (mesmas fases produzidas)
- [x] `noturno42h.test.js`: migrado (cycle_start=Fev/2025 produz mesma pattern que cycle_month=3)
- [x] `employees.test.js`: validações POST/PUT/default/null para os novos campos
- [x] Cenário: cycle_start=Jan/2026 gera fase 1 em Jan, 2 em Fev, 3 em Mar, 1 em Abr
- [x] Dois motoristas com cycle_start distintos geram fases distintas no mesmo mês
- [x] POST cycle_start_month=0 ou 13 retorna 400; null no PUT = no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)