### PR TITLE
feat(#72): histórico de gerações na sidebar da SchedulePage

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -29,6 +29,8 @@ export const schedulesApi = {
   updateEntry: (id, data) => client.put(`/schedules/entry/${id}`, data).then((r) => r.data),
   clearMonth: (month, year) =>
     client.delete('/schedules/month', { params: { month, year } }).then((r) => r.data),
+  getGenerations: (month, year) =>
+    client.get('/schedules/generations', { params: { month, year } }).then((r) => r.data),
 };
 
 // Vacations

--- a/frontend/src/components/schedule/GenerationHistory.jsx
+++ b/frontend/src/components/schedule/GenerationHistory.jsx
@@ -1,0 +1,94 @@
+import { useState, useEffect } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { schedulesApi } from '../../api/client.js';
+
+function formatDateTime(isoString) {
+  const d = new Date(isoString);
+  const dd = String(d.getDate()).padStart(2, '0');
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const hh = String(d.getHours()).padStart(2, '0');
+  const min = String(d.getMinutes()).padStart(2, '0');
+  return `${dd}/${mm} ${hh}:${min}`;
+}
+
+export default function GenerationHistory({ month, year }) {
+  const [generations, setGenerations] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setExpanded(null);
+    schedulesApi
+      .getGenerations(month, year)
+      .then(setGenerations)
+      .catch(() => setGenerations([]))
+      .finally(() => setLoading(false));
+  }, [month, year]);
+
+  if (loading) {
+    return <p className="text-xs text-gray-400 py-2">Carregando...</p>;
+  }
+
+  if (generations.length === 0) {
+    return (
+      <p className="text-xs text-gray-400 text-center py-4">
+        Nenhuma geração registrada para este período
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {generations.map((gen) => {
+        const isOpen = expanded === gen.id;
+        const warnings = gen.params_json?.warnings ?? [];
+        const warningCount = warnings.length;
+
+        return (
+          <div key={gen.id} className="border border-gray-200 rounded-lg overflow-hidden">
+            <button
+              className="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-gray-50 transition-colors"
+              onClick={() => setExpanded(isOpen ? null : gen.id)}
+            >
+              <div>
+                <p className="text-xs font-medium text-gray-700">
+                  {formatDateTime(gen.generated_at)}
+                </p>
+                <p className="text-[10px] text-gray-400">
+                  {warningCount > 0
+                    ? `${warningCount} aviso${warningCount > 1 ? 's' : ''}`
+                    : 'Sem avisos'}
+                </p>
+              </div>
+              {isOpen
+                ? <ChevronDown size={12} className="text-gray-400 shrink-0" />
+                : <ChevronRight size={12} className="text-gray-400 shrink-0" />}
+            </button>
+
+            {isOpen && (
+              <div className="px-3 pb-3 border-t border-gray-100 bg-gray-50">
+                {warningCount > 0 ? (
+                  <ul className="mt-2 space-y-1">
+                    {warnings.map((w, i) => (
+                      <li key={i} className="text-[10px] text-gray-600">
+                        • {w.message}
+                        {w.date && (
+                          <span className="text-gray-400 ml-1">({w.date})</span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-[10px] text-gray-400 mt-2">
+                    Nenhum aviso nesta geração.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/pages/SchedulePage.jsx
+++ b/frontend/src/pages/SchedulePage.jsx
@@ -16,6 +16,7 @@ import useStore from '../store/useStore.js';
 import CalendarView from '../components/schedule/CalendarView.jsx';
 import WeekView from '../components/schedule/WeekView.jsx';
 import MonthSummary from '../components/schedule/MonthSummary.jsx';
+import GenerationHistory from '../components/schedule/GenerationHistory.jsx';
 import EntryEditPopover from '../components/schedule/EntryEditPopover.jsx';
 import ConfirmDialog from '../components/shared/ConfirmDialog.jsx';
 import { exportApi } from '../api/client.js';
@@ -224,6 +225,12 @@ export default function SchedulePage() {
         {/* Sidebar summary */}
         <div className="w-56 border-l border-gray-200 p-4 overflow-y-auto bg-gray-50 shrink-0">
           <MonthSummary totals={scheduleData?.totals} />
+          <div className="mt-4 pt-4 border-t border-gray-200">
+            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+              Histórico
+            </h3>
+            <GenerationHistory month={currentMonth} year={currentYear} />
+          </div>
         </div>
       </div>
 

--- a/frontend/src/tests/GenerationHistory.test.jsx
+++ b/frontend/src/tests/GenerationHistory.test.jsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import GenerationHistory from '../components/schedule/GenerationHistory.jsx';
+import { schedulesApi } from '../api/client.js';
+
+vi.mock('../api/client.js', () => ({
+  schedulesApi: { getGenerations: vi.fn() },
+}));
+
+beforeEach(() => vi.clearAllMocks());
+
+const MONTH = 3;
+const YEAR = 2026;
+
+function makeGen(overrides = {}) {
+  return {
+    id: 1,
+    month: MONTH,
+    year: YEAR,
+    generated_at: '2026-03-02T21:00:00.000Z',
+    params_json: { warnings: [], weekClassifications: [] },
+    ...overrides,
+  };
+}
+
+// ── Estado vazio ───────────────────────────────────────────────────────────────
+
+describe('GenerationHistory — estado vazio', () => {
+  it('exibe "Nenhuma geração registrada" quando a lista está vazia', async () => {
+    schedulesApi.getGenerations.mockResolvedValue([]);
+    render(<GenerationHistory month={MONTH} year={YEAR} />);
+    await waitFor(() =>
+      expect(screen.getByText(/Nenhuma geração registrada para este período/i)).toBeInTheDocument()
+    );
+  });
+
+  it('exibe "Carregando..." enquanto aguarda a resposta', () => {
+    schedulesApi.getGenerations.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<GenerationHistory month={MONTH} year={YEAR} />);
+    expect(screen.getByText('Carregando...')).toBeInTheDocument();
+  });
+
+  it('exibe "Nenhuma geração" quando a API falha', async () => {
+    schedulesApi.getGenerations.mockRejectedValue(new Error('Network error'));
+    render(<GenerationHistory month={MONTH} year={YEAR} />);
+    await waitFor(() =>
+      expect(screen.getByText(/Nenhuma geração registrada para este período/i)).toBeInTheDocument()
+    );
+  });
+});
+
+// ── Lista de gerações ──────────────────────────────────────────────────────────
+
+describe('GenerationHistory — lista', () => {
+  it('exibe a data/hora formatada de cada geração', async () => {
+    schedulesApi.getGenerations.mockResolvedValue([
+      makeGen({ generated_at: '2026-03-02T21:30:00.000Z' }),
+    ]);
+    render(<GenerationHistory month={MONTH} year={YEAR} />);
+    // formato dd/mm hh:mm (horário local — valor exato depende do fuso)
+    await waitFor(() =>
+      expect(screen.getByText(/\d{2}\/\d{2} \d{2}:\d{2}/)).toBeInTheDocument()
+    );
+  });
+
+  it('exibe "Sem avisos" quando warnings está vazio', async () => {
+    schedulesApi.getGenerations.mockResolvedValue([makeGen()]);
+    render(<GenerationHistory month={MONTH} year={YEAR} />);
+    await waitFor(() =>
+      expect(screen.getByText('Sem avisos')).toBeInTheDocument()
+    );
+  });
+
+  it('exibe contagem de avisos quando há warnings', async () => {
+    schedulesApi.getGenerations.mockResolvedValue([
+      makeGen({ params_json: { warnings: [{ message: 'Aviso A' }, { message: 'Aviso B' }] } }),
+    ]);
+    render(<GenerationHistory month={MONTH} year={YEAR} />);
+    await waitFor(() =>
+      expect(screen.getByText('2 avisos')).toBeInTheDocument()
+    );
+  });
+
+  it('exibe "1 aviso" (singular) quando há exatamente 1 warning', async () => {
+    schedulesApi.getGenerations.mockResolvedValue([
+      makeGen({ params_json: { warnings: [{ message: 'Único aviso' }] } }),
+    ]);
+    render(<GenerationHistory month={MONTH} year={YEAR} />);
+    await waitFor(() =>
+      expect(screen.getByText('1 aviso')).toBeInTheDocument()
+    );
+  });
+
+  it('chama getGenerations com month e year corretos', async () => {
+    schedulesApi.getGenerations.mockResolvedValue([]);
+    render(<GenerationHistory month={5} year={2026} />);
+    await waitFor(() => expect(schedulesApi.getGenerations).toHaveBeenCalledWith(5, 2026));
+  });
+});
+
+// ── Expansão de item ───────────────────────────────────────────────────────────
+
+describe('GenerationHistory — expansão', () => {
+  it('conteúdo detalhado não aparece antes de expandir', async () => {
+    schedulesApi.getGenerations.mockResolvedValue([
+      makeGen({ params_json: { warnings: [{ message: 'Aviso X' }] } }),
+    ]);
+    render(<GenerationHistory month={MONTH} year={YEAR} />);
+    await waitFor(() => expect(screen.getByText('1 aviso')).toBeInTheDocument());
+    expect(screen.queryByText('• Aviso X')).not.toBeInTheDocument();
+  });
+
+  it('expande item ao clicar e exibe warnings', async () => {
+    schedulesApi.getGenerations.mockResolvedValue([
+      makeGen({ params_json: { warnings: [{ message: 'Cobertura insuficiente' }] } }),
+    ]);
+    render(<GenerationHistory month={MONTH} year={YEAR} />);
+    await waitFor(() => expect(screen.getByText('1 aviso')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('• Cobertura insuficiente')).toBeInTheDocument();
+  });
+
+  it('warning com date exibe a data entre parênteses', async () => {
+    schedulesApi.getGenerations.mockResolvedValue([
+      makeGen({
+        params_json: { warnings: [{ message: 'Plantão descoberto', date: '2026-03-15' }] },
+      }),
+    ]);
+    render(<GenerationHistory month={MONTH} year={YEAR} />);
+    await waitFor(() => expect(screen.getByText('1 aviso')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('• Plantão descoberto')).toBeInTheDocument();
+    expect(screen.getByText('(2026-03-15)')).toBeInTheDocument();
+  });
+
+  it('sem warnings expandido: exibe "Nenhum aviso nesta geração"', async () => {
+    schedulesApi.getGenerations.mockResolvedValue([makeGen()]);
+    render(<GenerationHistory month={MONTH} year={YEAR} />);
+    await waitFor(() => expect(screen.getByText('Sem avisos')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('Nenhum aviso nesta geração.')).toBeInTheDocument();
+  });
+
+  it('colapsa item ao clicar novamente', async () => {
+    schedulesApi.getGenerations.mockResolvedValue([
+      makeGen({ params_json: { warnings: [{ message: 'Aviso Y' }] } }),
+    ]);
+    render(<GenerationHistory month={MONTH} year={YEAR} />);
+    await waitFor(() => expect(screen.getByText('1 aviso')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('• Aviso Y')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByText('• Aviso Y')).not.toBeInTheDocument();
+  });
+
+  it('re-fetch ao mudar month/year e reseta expansão', async () => {
+    schedulesApi.getGenerations.mockResolvedValue([makeGen()]);
+    const { rerender } = render(<GenerationHistory month={3} year={2026} />);
+    await waitFor(() => expect(screen.getByText('Sem avisos')).toBeInTheDocument());
+
+    schedulesApi.getGenerations.mockResolvedValue([]);
+    rerender(<GenerationHistory month={4} year={2026} />);
+    await waitFor(() =>
+      expect(screen.getByText(/Nenhuma geração registrada/i)).toBeInTheDocument()
+    );
+    expect(schedulesApi.getGenerations).toHaveBeenCalledWith(4, 2026);
+  });
+});


### PR DESCRIPTION
## O que foi feito

Histórico de gerações visível diretamente na sidebar da SchedulePage.

### Arquivos alterados

| Arquivo | Mudança |
|---------|---------|
| `api/client.js` | +1 linha: `schedulesApi.getGenerations(month, year)` |
| `components/schedule/GenerationHistory.jsx` | novo componente |
| `pages/SchedulePage.jsx` | integra GenerationHistory na sidebar |
| `tests/GenerationHistory.test.jsx` | 14 testes |

### Comportamento

- Sidebar da SchedulePage exibe seção "Histórico" abaixo do MonthSummary
- Cada geração mostra: data/hora formatada + contagem de avisos
- Clique expande o item: lista warnings (message + date opcional)
- Estado vazio: "Nenhuma geração registrada para este período"
- Loading enquanto aguarda API; falha silenciosa (exibe estado vazio)
- Re-fetch automático ao navegar entre meses

### Evidência

```
103/103 testes frontend passando (6 arquivos)
```

🤖 Desenvolvedor Pleno — [Claude Code](https://claude.com/claude-code)