### PR TITLE
fix(frontend): torna label de duração do turno visível na tabela

### DIFF
--- a/frontend/src/components/schedule/WeekView.jsx
+++ b/frontend/src/components/schedule/WeekView.jsx
@@ -131,13 +131,15 @@ export default function WeekView({ scheduleData, currentMonth, currentYear, onEn
                       }
                     >
                       <span className="font-bold text-gray-800">{initial}</span>
-                      <span
-                        className={`block text-[8px] leading-none mt-0.5 font-semibold ${
-                          entry.duration_hours === 6 ? 'text-amber-700' : 'text-gray-600'
-                        }`}
-                      >
-                        {entry.duration_hours}h
-                      </span>
+                      {entry.duration_hours != null && (
+                        <span
+                          className={`block text-[11px] leading-none mt-0.5 font-semibold ${
+                            entry.duration_hours === 6 ? 'text-amber-700' : 'text-gray-900'
+                          }`}
+                        >
+                          {entry.duration_hours}h
+                        </span>
+                      )}
                       {entry.is_locked ? (
                         <span className="absolute top-0 right-0 text-gray-600">
                           <Lock size={8} />

--- a/frontend/src/tests/WeekView.test.jsx
+++ b/frontend/src/tests/WeekView.test.jsx
@@ -75,7 +75,7 @@ describe('WeekView — label de duração do turno', () => {
     expect(label).toHaveClass('text-amber-700');
   });
 
-  it('label "12h" não tem classe de destaque (text-gray-600)', () => {
+  it('label "12h" tem cor de alto contraste (text-gray-900)', () => {
     const entry = makeEntry({ duration_hours: 12 });
     render(
       <WeekView
@@ -85,8 +85,20 @@ describe('WeekView — label de duração do turno', () => {
       />
     );
     const label = screen.getByText('12h', { selector: 'span' });
-    expect(label).toHaveClass('text-gray-600');
+    expect(label).toHaveClass('text-gray-900');
     expect(label).not.toHaveClass('text-amber-700');
+  });
+
+  it('label de duração não renderiza quando duration_hours é null (null guard)', () => {
+    const entry = makeEntry({ duration_hours: null, is_day_off: 0 });
+    render(
+      <WeekView
+        scheduleData={makeScheduleData([entry])}
+        currentMonth={MONTH}
+        currentYear={YEAR}
+      />
+    );
+    expect(screen.queryByText('h', { selector: 'span' })).not.toBeInTheDocument();
   });
 
   it('célula de folga não exibe label de duração', () => {


### PR DESCRIPTION
## Problema

O label de horas dos turnos implementado em #77 era tecnicamente funcional — dados corretos chegavam da API — mas **visualmente invisível** por dois motivos:

- `text-[8px]`: fonte de 8px é extremamente pequena (metade do padrão de 16px)
- `text-gray-600`: cinza médio com contraste insuficiente sobre backgrounds coloridos dos turnos (roxo Noturno #818CF8, verde Diurno #34D399)

Resultado: o usuário via apenas a inicial do turno ("N", "D") sem conseguir ler as horas.

## Solução

| Antes | Depois | Motivo |
|-------|--------|--------|
| `text-[8px]` | `text-[11px]` | Legível em célula compacta (min-w-36px) |
| `text-gray-600` | `text-gray-900` | Alto contraste em todos os backgrounds de turno |
| sem guard | `duration_hours != null &&` | Evita render de `h` isolado quando campo é null |

`text-amber-700` (turnos 6h) mantido — já era visível em fundos amarelo/laranja.

## Testes

- Atualizado: expectativa de classe `text-gray-600` → `text-gray-900`
- Adicionado: null guard — quando `duration_hours` é null não renderiza label
- 104/104 testes passando