### PR TITLE
fix(generator): corrige turno extra 6h ausente em semana 42h NOTURNO (#82)

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -1285,7 +1285,12 @@ function hasAdequateRest(allEntries, targetEntry, shift, shiftMap) {
       const newStart = computeShiftStart(targetDate, shift);
       if (prevEnd && newStart) {
         const restMs = newStart - prevEnd;
-        if (restMs < MIN_REST_HOURS * 3_600_000) return false;
+        if (restMs === 0) {
+          if (!isValidEmendado(prevShift.name, shift.name)) return false;
+          if (prevShift.duration_hours + shift.duration_hours > MAX_CONSECUTIVE_HOURS) return false;
+        } else if (restMs < 0 || restMs < MIN_REST_HOURS * 3_600_000) {
+          return false;
+        }
       }
     }
   }
@@ -1299,7 +1304,12 @@ function hasAdequateRest(allEntries, targetEntry, shift, shiftMap) {
       const nextStart = computeShiftStart(next.date, nextShift);
       if (newEnd && nextStart) {
         const restMs = nextStart - newEnd;
-        if (restMs < MIN_REST_HOURS * 3_600_000) return false;
+        if (restMs === 0) {
+          if (!isValidEmendado(shift.name, nextShift.name)) return false;
+          if (shift.duration_hours + nextShift.duration_hours > MAX_CONSECUTIVE_HOURS) return false;
+        } else if (restMs < 0 || restMs < MIN_REST_HOURS * 3_600_000) {
+          return false;
+        }
       }
     }
   }
@@ -1366,7 +1376,10 @@ export function correctHours(
     return inMemoryWeeklyHours(wm.weekStart, wm.weekEnd) + shiftToAdd.duration_hours > cltLimit.limit;
   }
 
-  const workEntries = entries.filter((e) => !e.is_day_off && e.shift_type_id);
+  // Ao remover turnos (diff > 6), remover primeiro os de maior duração (12h antes de 6h extra).
+  const workEntries = entries
+    .filter((e) => !e.is_day_off && e.shift_type_id)
+    .sort((a, b) => (shiftMap[b.shift_type_id]?.duration_hours || 0) - (shiftMap[a.shift_type_id]?.duration_hours || 0));
   const offEntries  = entries.filter((e) => e.is_day_off);
 
   if (diff > 6) {
@@ -1388,22 +1401,42 @@ export function correctHours(
       preferredShift ||
       shiftTypes.find((s) => s.duration_hours === DEFAULT_SHIFT_HOURS) ||
       shiftTypes[0];
+
+    // Fallback 6h (Manhã/Tarde) para NOTURNO em semana 42h — quando o turno preferido (12h)
+    // excederia o limite semanal de 42h já parcialmente preenchido por 3×12h=36h.
+    const manhaFallback = isNoturno ? shiftTypes.find((s) => s.name === SHIFT_MANHA_NAME) : null;
+    const tardeFallback = isNoturno ? shiftTypes.find((s) => s.name === SHIFT_TARDE_NAME) : null;
+    const sixHourFallbacks = [manhaFallback, tardeFallback].filter(Boolean);
+
     let deficit = Math.abs(diff);
     for (const entry of offEntries) {
       if (deficit <= 0) break;
       if (lockedOffDates.has(entry.date)) continue;
-      if (!hasAdequateRest(entries, entry, shiftToAdd, shiftMap)) continue;
-      if (wouldExceedConsecutive(entries, entry)) continue;
 
-      // Verificação do limite semanal CLT
+      // Determina o turno candidato respeitando o limite semanal CLT.
+      let candidateShift = shiftToAdd;
       if (weeks.length > 0 && effectiveCycleMonth !== null) {
         const wm = weekMetaFor(entry.date);
-        if (wm && wouldExceedWeeklyLimit(wm, shiftToAdd)) continue;
+        if (wm && wouldExceedWeeklyLimit(wm, candidateShift)) {
+          // Para NOTURNO em semana 42h, tenta turno extra de 6h como fallback.
+          if (isNoturno && wm.weekType === '42h' && sixHourFallbacks.length > 0) {
+            candidateShift = null;
+            for (const sixH of sixHourFallbacks) {
+              if (!wouldExceedWeeklyLimit(wm, sixH)) { candidateShift = sixH; break; }
+            }
+            if (!candidateShift) continue;
+          } else {
+            continue;
+          }
+        }
       }
 
+      if (!hasAdequateRest(entries, entry, candidateShift, shiftMap)) continue;
+      if (wouldExceedConsecutive(entries, entry)) continue;
+
       entry.is_day_off = 0;
-      entry.shift_type_id = shiftToAdd.id;
-      deficit -= shiftToAdd.duration_hours;
+      entry.shift_type_id = candidateShift.id;
+      deficit -= candidateShift.duration_hours;
     }
   }
 

--- a/backend/src/tests/scheduleGenerator.unit.test.js
+++ b/backend/src/tests/scheduleGenerator.unit.test.js
@@ -76,6 +76,84 @@ describe('correctHours', () => {
     expect(converted.length).toBeGreaterThan(5); // folgas boas foram convertidas
   });
 
+  // ── Issue #82 — fixes ────────────────────────────────────────────────────────
+
+  it('hasAdequateRest: aceita posição emendado Noturno→Manhã (restMs=0) ao converter folga', () => {
+    // Jan 5 Noturno (19:00→Jan 6 07:00); Jan 6 off está em posição emendado (0h rest).
+    // Com fix #1: isValidEmendado(Noturno, Manhã)=true + 12+6≤18 → aceita.
+    // Sem fix: restMs=0 < 24h → rejeitaria → motorista não receberia o turno.
+    const noturno = { id: 1, name: 'Noturno', duration_hours: 12, start_time: '19:00' };
+    const manha   = { id: 2, name: 'Manhã',   duration_hours: 6,  start_time: '07:00' };
+    const localShiftTypes = [noturno, manha];
+    const localShiftMap   = { 1: noturno, 2: manha };
+
+    const entries = [
+      { employee_id: 1, date: '2025-01-05', is_day_off: 0, shift_type_id: 1, is_locked: 0 },
+      { employee_id: 1, date: '2025-01-06', is_day_off: 1, shift_type_id: null, is_locked: 0 },
+      { employee_id: 1, date: '2025-01-07', is_day_off: 1, shift_type_id: null, is_locked: 0 },
+    ];
+    // currentHours=12, target=24, diff=-12 < -6 → tenta converter folgas; preferredShift=Manhã
+    correctHours(entries, localShiftTypes, localShiftMap, 12, 24, manha);
+
+    const jan6 = entries.find((e) => e.date === '2025-01-06');
+    expect(jan6.is_day_off).toBe(0);          // convertida — emendado Noturno→Manhã válido
+    expect(jan6.shift_type_id).toBe(manha.id);
+  });
+
+  it('diff>6: remove turno de 12h antes do turno extra de 6h (Manhã) ao reduzir excesso', () => {
+    // 6h Manhã em Jan 1 (entrada mais cedo) + 14×12h Noturno = 174h; diff=14 > 6.
+    // Com fix #2 (sort desc): remove um Noturno 12h primeiro → 162h, excess=2 ≤ 6 → Manhã preservada.
+    // Sem fix (ordem de inserção): remove Manhã 6h primeiro → 168h, excess=8 → remove outro 12h → 156h.
+    const noturno = { id: 1, name: 'Noturno', duration_hours: 12 };
+    const manha   = { id: 2, name: 'Manhã',   duration_hours: 6  };
+    const localShiftTypes = [noturno, manha];
+    const localShiftMap   = { 1: noturno, 2: manha };
+
+    const entries = [
+      { employee_id: 1, date: '2025-01-01', is_day_off: 0, shift_type_id: 2, is_locked: 0 }, // 6h
+    ];
+    for (let i = 2; i <= 15; i++) {
+      entries.push({ employee_id: 1, date: `2025-01-${String(i).padStart(2,'0')}`, is_day_off: 0, shift_type_id: 1, is_locked: 0 });
+    }
+
+    correctHours(entries, localShiftTypes, localShiftMap, 174, 160);
+
+    const jan1 = entries.find((e) => e.date === '2025-01-01');
+    expect(jan1.is_day_off).toBe(0); // Manhã 6h preservada — Noturno 12h foi removido primeiro
+    expect(jan1.shift_type_id).toBe(manha.id);
+  });
+
+  it('diff<-6 NOTURNO em semana 42h: usa Manhã (6h) como fallback quando 12h excederia limite semanal', () => {
+    // 3×Noturno (36h) em semana 42h + 1 off em posição emendado (Jan 6 = dia após Jan 5 Noturno).
+    // Adicionarnoturno: 36+12=48 > 42 → limite excedido → fallback para Manhã 6h (Fix #3).
+    // Jan 6 emendado: restMs=0, Noturno→Manhã válido → aceito (Fix #1).
+    const noturno = { id: 1, name: 'Noturno', duration_hours: 12, start_time: '19:00' };
+    const manha   = { id: 2, name: 'Manhã',   duration_hours: 6,  start_time: '07:00' };
+    const tarde   = { id: 3, name: 'Tarde',   duration_hours: 6,  start_time: '13:00' };
+    const localShiftTypes = [noturno, manha, tarde];
+    const localShiftMap   = { 1: noturno, 2: manha, 3: tarde };
+
+    const entries = [
+      { employee_id: 1, date: '2025-01-05', is_day_off: 0, shift_type_id: 1, is_locked: 0 }, // Dom Noturno
+      { employee_id: 1, date: '2025-01-06', is_day_off: 1, shift_type_id: null, is_locked: 0 }, // Seg off (emendado)
+      { employee_id: 1, date: '2025-01-07', is_day_off: 0, shift_type_id: 1, is_locked: 0 }, // Ter Noturno
+      { employee_id: 1, date: '2025-01-08', is_day_off: 1, shift_type_id: null, is_locked: 0 }, // Qua off
+      { employee_id: 1, date: '2025-01-09', is_day_off: 0, shift_type_id: 1, is_locked: 0 }, // Qui Noturno
+      { employee_id: 1, date: '2025-01-10', is_day_off: 1, shift_type_id: null, is_locked: 0 }, // Sex off
+      { employee_id: 1, date: '2025-01-11', is_day_off: 1, shift_type_id: null, is_locked: 0 }, // Sab off
+    ];
+
+    // 1 semana: Jan 5–11; effectiveCycleMonth=2 → getWeekTypeFromPhase(2,0)='42h'
+    const weeks = [['2025-01-05','2025-01-06','2025-01-07','2025-01-08','2025-01-09','2025-01-10','2025-01-11']];
+
+    // currentHours=36, target=84, diff=-48 < -6 → tenta converter folgas com preferredShift=Noturno
+    correctHours(entries, localShiftTypes, localShiftMap, 36, 84, noturno, new Set(), weeks, 2);
+
+    const jan6 = entries.find((e) => e.date === '2025-01-06');
+    expect(jan6.is_day_off).toBe(0);          // convertida via fallback 6h
+    expect(jan6.shift_type_id).toBe(manha.id); // Manhã (primeiro fallback) escolhida
+  });
+
   it('não converte folga que criaria mais de 6 dias consecutivos de trabalho', () => {
     // Turno sem start_time — wouldExceedConsecutive opera por data de calendário (independe de start_time)
     const turno = { id: 1, name: 'Noturno', duration_hours: 12 };


### PR DESCRIPTION
## Problema

Turno extra de 6h (Manha/Tarde) estava ausente em semanas 42h para motoristas NOTURNO. Bug pre-existente exposto pelo PR #81 (que adicionou verificacao de limite semanal CLT em correctHours).

## Causa raiz

Tres bugs interconectados em scheduleGenerator.js:

### Bug 1 - hasAdequateRest rejeitava emendado Noturno->Manha
- restMs === 0 era tratado como violacao de descanso (< 24h)
- canAddExtraShiftInMemory tratava corretamente, hasAdequateRest nao
- Resultado: correctHours nao conseguia converter folga em posicao emendada em Manha

### Bug 2 - correctHours diff>6 removia 6h antes de 12h
- workEntries nao ordenados -> iteracao em ordem cronologica
- Se Manha 6h era a entrada mais antiga, era removida antes de Noturno 12h

### Bug 3 - correctHours diff<-6 sem fallback 6h para NOTURNO 42h
- Ao tentar cobrir deficit, so tentava preferredShift (Noturno 12h)
- Com limite semanal 42h ja em 36h, 12h excederia o limite -> pulava
- Nenhum fallback para Manha/Tarde (6h) que caberia no limite

## Solucao

1. hasAdequateRest: restMs === 0 -> valida via isValidEmendado + MAX_CONSECUTIVE_HOURS, identico a canAddExtraShiftInMemory
2. workEntries sort desc: remove turnos de maior duracao primeiro (12h antes de 6h)
3. Fallback 6h: para isNoturno && weekType === '42h', tenta Manha/Tarde quando 12h excederia limite semanal

Os fixes 1 e 3 trabalham em conjunto: fix 3 seleciona Manha como candidata; fix 1 permite que hasAdequateRest aceite a posicao emendado Noturno->Manha (restMs=0).

## Arquivos alterados

- backend/src/services/scheduleGenerator.js - 3 fixes cirurgicos
- backend/src/tests/scheduleGenerator.unit.test.js - 3 unit tests novos (Fix 1, 2 e 3)

## Evidencia de teste

```
checkmark scheduleGenerator.unit.test.js (40 tests)
checkmark noturno42h.test.js (5 tests - todos mantidos)
Test Files  14 passed (14)
      Tests  197 passed (197) - backend
      Tests  104 passed (104) - frontend
```

Closes #82