### PR TITLE
test(frontend): cobertura SchedulePage e WeekView (#73)

### DIFF
--- a/frontend/src/tests/SchedulePage.test.jsx
+++ b/frontend/src/tests/SchedulePage.test.jsx
@@ -1,0 +1,204 @@
+/**
+ * test(frontend): cobertura SchedulePage — issue #73
+ *
+ * Tester Senior
+ *
+ * Critérios de aceite:
+ *   - Renderiza seletor de mês/ano
+ *   - Exibe loading quando scheduleLoading=true
+ *   - Exibe mensagem quando sem funcionários cadastrados
+ *   - Botão "Gerar Escala" chama generateSchedule e propaga warnings
+ *   - Botão "Limpar" abre ConfirmDialog; confirmar chama clearSchedule
+ *
+ * Estratégia: useStore mockado; componentes filhos complexos mockados;
+ * ConfirmDialog real (já testado em isolamento e compatível com jsdom).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import SchedulePage from '../pages/SchedulePage.jsx';
+import useStore from '../store/useStore.js';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../store/useStore.js', () => ({ default: vi.fn() }));
+vi.mock('../api/client.js', () => ({
+  exportApi: { excel: vi.fn(), pdf: vi.fn() },
+}));
+vi.mock('../components/schedule/WeekView.jsx', () => ({
+  default: vi.fn(() => <div data-testid="week-view" />),
+}));
+vi.mock('../components/schedule/CalendarView.jsx', () => ({
+  default: () => <div data-testid="calendar-view" />,
+}));
+vi.mock('../components/schedule/GenerationHistory.jsx', () => ({
+  default: () => null,
+}));
+vi.mock('../components/schedule/MonthSummary.jsx', () => ({
+  default: () => null,
+}));
+vi.mock('../components/schedule/EntryEditPopover.jsx', () => ({
+  default: () => null,
+}));
+
+// ── mockStore base ─────────────────────────────────────────────────────────────
+
+const mockStore = {
+  currentMonth: 3,
+  currentYear: 2026,
+  scheduleData: null,
+  scheduleLoading: false,
+  scheduleGenerating: false,
+  employees: [{ id: 1, name: 'Ana' }],
+  setCurrentPeriod: vi.fn(),
+  generateSchedule: vi.fn(),
+  clearSchedule: vi.fn(),
+  fetchShiftTypes: vi.fn(),
+  fetchEmployees: vi.fn(),
+  addToast: vi.fn(),
+  setWarnings: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useStore.mockReturnValue(mockStore);
+  mockStore.generateSchedule.mockResolvedValue({ warnings: [], results: [] });
+  mockStore.clearSchedule.mockResolvedValue();
+});
+
+// ── Seletor de mês/ano ────────────────────────────────────────────────────────
+
+describe('SchedulePage — seletor de mês/ano', () => {
+  it('exibe o mês e ano atuais no seletor de navegação', () => {
+    render(<SchedulePage />);
+    expect(screen.getByText('Março 2026')).toBeInTheDocument();
+  });
+
+  it('navegar para o mês anterior chama setCurrentPeriod com mês=2 ano=2026', () => {
+    render(<SchedulePage />);
+    // Botão com ChevronLeft — primeiro botão de navegação
+    const [prevBtn] = screen.getAllByRole('button').filter(
+      (btn) => btn.querySelector('svg')
+    );
+    // Usa o primeiro botão de ícone (ChevronLeft)
+    const navButtons = screen.getAllByRole('button');
+    // ChevronLeft é o primeiro botão com apenas SVG (sem texto)
+    const chev = navButtons.find((b) => !b.textContent.trim());
+    fireEvent.click(chev);
+    expect(mockStore.setCurrentPeriod).toHaveBeenCalledWith(2, 2026);
+  });
+});
+
+// ── Estados de carregamento ────────────────────────────────────────────────────
+
+describe('SchedulePage — estados de carregamento', () => {
+  it('exibe indicador de carregamento quando scheduleLoading=true', () => {
+    useStore.mockReturnValue({ ...mockStore, scheduleLoading: true });
+    render(<SchedulePage />);
+    expect(screen.getByText(/Carregando escala/i)).toBeInTheDocument();
+  });
+
+  it('exibe mensagem orientando cadastro quando não há funcionários', () => {
+    useStore.mockReturnValue({ ...mockStore, employees: [] });
+    render(<SchedulePage />);
+    expect(screen.getByText(/Cadastre funcionários/i)).toBeInTheDocument();
+  });
+
+  it('botão Gerar Escala está desabilitado quando não há funcionários', () => {
+    useStore.mockReturnValue({ ...mockStore, employees: [] });
+    render(<SchedulePage />);
+    expect(screen.getByRole('button', { name: /Gerar Escala/i })).toBeDisabled();
+  });
+
+  it('renderiza WeekView quando há funcionários e scheduleLoading=false', () => {
+    render(<SchedulePage />);
+    expect(screen.getByTestId('week-view')).toBeInTheDocument();
+  });
+});
+
+// ── Gerar Escala ──────────────────────────────────────────────────────────────
+
+describe('SchedulePage — botão Gerar Escala', () => {
+  it('chama generateSchedule diretamente quando não há escala existente', async () => {
+    // scheduleData=null → hasSchedule=false → sem ConfirmDialog intermediário
+    render(<SchedulePage />);
+    fireEvent.click(screen.getByRole('button', { name: /Gerar Escala/i }));
+    await waitFor(() => {
+      expect(mockStore.generateSchedule).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('propaga warnings do resultado para setWarnings no store', async () => {
+    const warnings = [{ employee: 'Ana', message: 'desvio de +14h' }];
+    mockStore.generateSchedule.mockResolvedValue({ warnings, results: [{}] });
+    render(<SchedulePage />);
+    fireEvent.click(screen.getByRole('button', { name: /Gerar Escala/i }));
+    await waitFor(() => {
+      expect(mockStore.setWarnings).toHaveBeenCalledWith(warnings);
+    });
+  });
+
+  it('abre ConfirmDialog de regeração quando já há escala existente', async () => {
+    useStore.mockReturnValue({
+      ...mockStore,
+      scheduleData: { entries: [{ id: 1 }] },
+    });
+    render(<SchedulePage />);
+    fireEvent.click(screen.getByRole('button', { name: /Gerar Escala/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Regerar escala')).toBeInTheDocument();
+    });
+  });
+
+  it('confirmar regeração chama generateSchedule', async () => {
+    useStore.mockReturnValue({
+      ...mockStore,
+      scheduleData: { entries: [{ id: 1 }] },
+    });
+    render(<SchedulePage />);
+    fireEvent.click(screen.getByRole('button', { name: /Gerar Escala/i }));
+    await waitFor(() => screen.getByRole('button', { name: /Regerar/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Regerar/i }));
+    await waitFor(() => {
+      expect(mockStore.generateSchedule).toHaveBeenCalledWith(false);
+    });
+  });
+});
+
+// ── Limpar Escala ─────────────────────────────────────────────────────────────
+
+describe('SchedulePage — botão Limpar', () => {
+  const storeComEscala = () =>
+    useStore.mockReturnValue({ ...mockStore, scheduleData: { entries: [{ id: 1 }] } });
+
+  it('botão Limpar não é exibido quando não há escala', () => {
+    render(<SchedulePage />);
+    expect(screen.queryByRole('button', { name: /Limpar/i })).not.toBeInTheDocument();
+  });
+
+  it('botão Limpar é exibido quando há escala existente', () => {
+    storeComEscala();
+    render(<SchedulePage />);
+    expect(screen.getByRole('button', { name: /Limpar/i })).toBeInTheDocument();
+  });
+
+  it('clique em Limpar abre ConfirmDialog de confirmação', async () => {
+    storeComEscala();
+    render(<SchedulePage />);
+    fireEvent.click(screen.getByRole('button', { name: /Limpar/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Limpar escala')).toBeInTheDocument();
+    });
+  });
+
+  it('confirmar diálogo de limpar chama clearSchedule', async () => {
+    storeComEscala();
+    render(<SchedulePage />);
+    fireEvent.click(screen.getByRole('button', { name: /Limpar/i }));
+    await waitFor(() => screen.getByRole('button', { name: /Limpar tudo/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Limpar tudo/i }));
+    await waitFor(() => {
+      expect(mockStore.clearSchedule).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/tests/WeekView.test.jsx
+++ b/frontend/src/tests/WeekView.test.jsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import WeekView from '../components/schedule/WeekView.jsx';
 
 const MONTH = 3;
@@ -179,5 +179,123 @@ describe('WeekView — renderização base', () => {
       />
     );
     expect(screen.getByText('F')).toBeInTheDocument();
+  });
+});
+
+// ── Cabeçalho de dias (issue #73) ─────────────────────────────────────────────
+
+describe('WeekView — cabeçalho de dias (issue #73)', () => {
+  it('exibe todos os 7 labels de dias da semana no cabeçalho', () => {
+    // Março 2026 começa no domingo — todos os 7 labels aparecem ao menos uma vez.
+    render(
+      <WeekView
+        scheduleData={makeScheduleData([makeEntry()])}
+        currentMonth={MONTH}
+        currentYear={YEAR}
+      />
+    );
+    for (const label of ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb']) {
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── Interação de clique (issue #73) ───────────────────────────────────────────
+
+describe('WeekView — interação de clique (issue #73)', () => {
+  it('clique em célula de turno chama onEntryClick com a entry correta', () => {
+    const onEntryClick = vi.fn();
+    const entry = makeEntry();
+    render(
+      <WeekView
+        scheduleData={makeScheduleData([entry])}
+        currentMonth={MONTH}
+        currentYear={YEAR}
+        onEntryClick={onEntryClick}
+      />
+    );
+    // Clica na inicial do turno ('N' de Noturno) — evento burbulha até o td
+    fireEvent.click(screen.getByText('N'));
+    expect(onEntryClick).toHaveBeenCalledOnce();
+    expect(onEntryClick).toHaveBeenCalledWith(entry);
+  });
+
+  it('clique em célula de folga chama onEntryClick com a entry correta', () => {
+    const onEntryClick = vi.fn();
+    const entry = makeEntry({ is_day_off: 1 });
+    render(
+      <WeekView
+        scheduleData={makeScheduleData([entry])}
+        currentMonth={MONTH}
+        currentYear={YEAR}
+        onEntryClick={onEntryClick}
+      />
+    );
+    fireEvent.click(screen.getByText('F'));
+    expect(onEntryClick).toHaveBeenCalledOnce();
+    expect(onEntryClick).toHaveBeenCalledWith(entry);
+  });
+
+  it('célula bloqueada exibe ícone de cadeado (Lock svg)', () => {
+    const entry = makeEntry({ is_locked: 1 });
+    const { container } = render(
+      <WeekView
+        scheduleData={makeScheduleData([entry])}
+        currentMonth={MONTH}
+        currentYear={YEAR}
+      />
+    );
+    // Lock de lucide-react renderiza como SVG
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('célula não-bloqueada não exibe ícone de cadeado', () => {
+    const entry = makeEntry({ is_locked: 0 });
+    const { container } = render(
+      <WeekView
+        scheduleData={makeScheduleData([entry])}
+        currentMonth={MONTH}
+        currentYear={YEAR}
+      />
+    );
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+});
+
+// ── Coluna de total (issue #73) ────────────────────────────────────────────────
+
+describe('WeekView — coluna de total (issue #73)', () => {
+  it('total do motorista exibe soma das horas de trabalho do mês', () => {
+    const entries = [
+      makeEntry({ id: 1, date: '2026-03-03', duration_hours: 12 }),
+      makeEntry({ id: 2, date: '2026-03-05', duration_hours: 12 }),
+      makeEntry({ id: 3, date: '2026-03-07', duration_hours: 12 }),
+    ];
+    render(
+      <WeekView scheduleData={makeScheduleData(entries)} currentMonth={MONTH} currentYear={YEAR} />
+    );
+    expect(screen.getByText('36h', { selector: 'td' })).toBeInTheDocument();
+  });
+
+  it('total dentro de ±12h de 160h tem classe text-green-700', () => {
+    // 13 × 12h = 156h — desvio de -4h, dentro do intervalo ±12h
+    const entries = Array.from({ length: 13 }, (_, i) => makeEntry({
+      id: i + 1,
+      date: `2026-03-${String(i + 1).padStart(2, '0')}`,
+      duration_hours: 12,
+    }));
+    render(
+      <WeekView scheduleData={makeScheduleData(entries)} currentMonth={MONTH} currentYear={YEAR} />
+    );
+    expect(screen.getByText('156h', { selector: 'td' })).toHaveClass('text-green-700');
+  });
+
+  it('total fora de ±12h de 160h tem classe text-orange-600', () => {
+    // 1 × 12h = 12h — desvio de -148h, fora do intervalo ±12h
+    const entry = makeEntry({ duration_hours: 12 });
+    render(
+      <WeekView scheduleData={makeScheduleData([entry])} currentMonth={MONTH} currentYear={YEAR} />
+    );
+    expect(screen.getByText('12h', { selector: 'td' })).toHaveClass('text-orange-600');
   });
 });


### PR DESCRIPTION
## Escopo

Cobertura frontend dos componentes SchedulePage e WeekView — issue #73.

## Testes adicionados

### SchedulePage.test.jsx (novo — 14 testes)

Estrategia: useStore mockado via vi.fn(); componentes filhos complexos (WeekView, CalendarView, GenerationHistory, MonthSummary, EntryEditPopover) mockados; ConfirmDialog real (compativel com jsdom via setup.js).

- Seletor de mês/ano: exibe "Marco 2026"; navegacao anterior chama setCurrentPeriod(2, 2026)
- Loading: "Carregando escala..." quando scheduleLoading=true
- Sem funcionarios: "Cadastre funcionarios..." quando employees=[]; botao Gerar desabilitado
- WeekView renderizado quando ha funcionarios e viewMode=table
- Gerar Escala: chama generateSchedule(false) direto quando sem escala; propaga warnings ao store; abre ConfirmDialog quando ha escala; confirmar chama generateSchedule
- Limpar: ausente sem escala; visivel com escala; abre ConfirmDialog; confirmar chama clearSchedule

### WeekView.test.jsx (+8 testes, 19 total)

- Cabecalho: os 7 labels de dias (Dom, Seg, Ter, Qua, Qui, Sex, Sab) presentes em Marco/2026
- Clique em turno: onEntryClick chamado com a entry correta
- Clique em folga: onEntryClick chamado com a entry correta
- Celula bloqueada: Lock SVG presente; nao-bloqueada: Lock ausente
- Total do motorista: soma das horas exibida; text-green-700 dentro de +-12h; text-orange-600 fora

## Evidencia

```
checkmark WeekView.test.jsx (19 tests)
checkmark SchedulePage.test.jsx (14 tests)
Test Files  7 passed (7)
      Tests  126 passed (126) - frontend
      Tests  197 passed (197) - backend
```

Closes #73