### PR TITLE
feat(frontend): busca por nome + dropdown de setor em EmployeesPage (#74)

### DIFF
--- a/frontend/src/pages/EmployeesPage.jsx
+++ b/frontend/src/pages/EmployeesPage.jsx
@@ -5,9 +5,12 @@ import EmployeeCard from '../components/employees/EmployeeCard.jsx';
 import EmployeeForm from '../components/employees/EmployeeForm.jsx';
 import ConfirmDialog from '../components/shared/ConfirmDialog.jsx';
 
+const SETORES = ['Transporte Ambulância', 'Transporte Hemodiálise', 'Transporte Administrativo'];
+
 export default function EmployeesPage() {
   const { employees, employeesLoading, fetchEmployees, deleteEmployee, shiftTypes, fetchShiftTypes, addToast } = useStore();
   const [search, setSearch] = useState('');
+  const [filterSetor, setFilterSetor] = useState('');
   const [formOpen, setFormOpen] = useState(false);
   const [editingEmployee, setEditingEmployee] = useState(null);
   const [deleteTarget, setDeleteTarget] = useState(null);
@@ -17,12 +20,13 @@ export default function EmployeesPage() {
     fetchShiftTypes();
   }, []);
 
-  const filtered = employees.filter(
-    (e) =>
-      e.name.toLowerCase().includes(search.toLowerCase()) ||
-      e.cargo.toLowerCase().includes(search.toLowerCase()) ||
-      (e.setores || []).some((s) => s.toLowerCase().includes(search.toLowerCase()))
-  );
+  const hasFilters = search.trim() !== '' || filterSetor !== '';
+
+  const filtered = employees.filter((e) => {
+    const matchName = search.trim() === '' || e.name.toLowerCase().includes(search.toLowerCase());
+    const matchSetor = filterSetor === '' || (e.setores || []).includes(filterSetor);
+    return matchName && matchSetor;
+  });
 
   const handleEdit = (employee) => {
     setEditingEmployee(employee);
@@ -62,15 +66,36 @@ export default function EmployeesPage() {
         </button>
       </div>
 
-      {/* Search */}
-      <div className="relative mb-6 max-w-sm">
-        <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
-        <input
-          className="input pl-9"
-          placeholder="Buscar por nome, cargo ou setor..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
+      {/* Search + Setor filter */}
+      <div className="flex flex-wrap gap-3 mb-6">
+        <div className="relative max-w-sm flex-1 min-w-[180px]">
+          <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            className="input pl-9 w-full"
+            placeholder="Buscar por nome..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <select
+          className="input max-w-xs"
+          value={filterSetor}
+          onChange={(e) => setFilterSetor(e.target.value)}
+          aria-label="Filtrar por setor"
+        >
+          <option value="">Todos os setores</option>
+          {SETORES.map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+        {hasFilters && (
+          <button
+            className="btn-ghost text-sm text-gray-500"
+            onClick={() => { setSearch(''); setFilterSetor(''); }}
+          >
+            Limpar filtros
+          </button>
+        )}
       </div>
 
       {/* Content */}
@@ -80,9 +105,11 @@ export default function EmployeesPage() {
         <div className="flex flex-col items-center justify-center h-48 text-gray-400 gap-2">
           <Users size={40} className="text-gray-300" />
           <p className="text-sm">
-            {search ? 'Nenhum motorista encontrado' : 'Nenhum motorista cadastrado'}
+            {hasFilters
+              ? 'Nenhum motorista encontrado para os filtros aplicados'
+              : 'Nenhum motorista cadastrado'}
           </p>
-          {!search && (
+          {!hasFilters && (
             <button
               className="btn-primary mt-2"
               onClick={() => {

--- a/frontend/src/tests/EmployeesPage.test.jsx
+++ b/frontend/src/tests/EmployeesPage.test.jsx
@@ -1,0 +1,224 @@
+/**
+ * test(frontend): cobertura EmployeesPage — issue #74
+ *
+ * Desenvolvedor Pleno
+ *
+ * Critérios de aceite:
+ *   - Input de busca por nome filtra a lista em tempo real
+ *   - Dropdown de setor filtra por `setores` do motorista
+ *   - Combinação nome + setor aplica ambos os filtros simultaneamente
+ *   - Resultado vazio exibe mensagem descritiva
+ *   - Filtros não disparam requests ao backend
+ *   - Botão "Limpar filtros" restaura a lista completa
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EmployeesPage from '../pages/EmployeesPage.jsx';
+import useStore from '../store/useStore.js';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../store/useStore.js', () => ({ default: vi.fn() }));
+vi.mock('../api/client.js', () => ({
+  employeesApi: { list: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+  shiftTypesApi: { list: vi.fn() },
+}));
+vi.mock('../components/employees/EmployeeCard.jsx', () => ({
+  default: ({ employee }) => <div data-testid="employee-card">{employee.name}</div>,
+}));
+vi.mock('../components/employees/EmployeeForm.jsx', () => ({
+  default: () => null,
+}));
+vi.mock('../components/shared/ConfirmDialog.jsx', () => ({
+  default: () => null,
+}));
+
+// ── Dados de teste ────────────────────────────────────────────────────────────
+
+const EMPLOYEES = [
+  { id: 1, name: 'Ana',   cargo: 'Motorista', setores: ['Transporte Ambulância'],  color: '#aaa' },
+  { id: 2, name: 'Bruno', cargo: 'Motorista', setores: ['Transporte Hemodiálise'], color: '#bbb' },
+  { id: 3, name: 'Cida',  cargo: 'Motorista', setores: ['Transporte Ambulância'],  color: '#ccc' },
+];
+
+const mockStore = {
+  employees: EMPLOYEES,
+  employeesLoading: false,
+  fetchEmployees: vi.fn(),
+  deleteEmployee: vi.fn(),
+  shiftTypes: [],
+  fetchShiftTypes: vi.fn(),
+  addToast: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useStore.mockReturnValue({ ...mockStore, employees: EMPLOYEES });
+});
+
+// ── Renderização base ─────────────────────────────────────────────────────────
+
+describe('EmployeesPage — renderização base', () => {
+  it('exibe todos os motoristas sem filtro ativo', () => {
+    render(<EmployeesPage />);
+    expect(screen.getAllByTestId('employee-card')).toHaveLength(3);
+    expect(screen.getByText('Ana')).toBeInTheDocument();
+    expect(screen.getByText('Bruno')).toBeInTheDocument();
+    expect(screen.getByText('Cida')).toBeInTheDocument();
+  });
+
+  it('exibe campo de busca por nome e dropdown de setor', () => {
+    render(<EmployeesPage />);
+    expect(screen.getByPlaceholderText('Buscar por nome...')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /Filtrar por setor/i })).toBeInTheDocument();
+  });
+
+  it('botão "Limpar filtros" não é exibido quando não há filtros ativos', () => {
+    render(<EmployeesPage />);
+    expect(screen.queryByRole('button', { name: /Limpar filtros/i })).not.toBeInTheDocument();
+  });
+
+  it('sem motoristas cadastrados exibe "Nenhum motorista cadastrado"', () => {
+    useStore.mockReturnValue({ ...mockStore, employees: [] });
+    render(<EmployeesPage />);
+    expect(screen.getByText('Nenhum motorista cadastrado')).toBeInTheDocument();
+  });
+});
+
+// ── Busca por nome ────────────────────────────────────────────────────────────
+
+describe('EmployeesPage — busca por nome', () => {
+  it('filtra motoristas pelo nome em tempo real', () => {
+    render(<EmployeesPage />);
+    fireEvent.change(screen.getByPlaceholderText('Buscar por nome...'), { target: { value: 'Ana' } });
+    expect(screen.getAllByTestId('employee-card')).toHaveLength(1);
+    expect(screen.getByText('Ana')).toBeInTheDocument();
+    expect(screen.queryByText('Bruno')).not.toBeInTheDocument();
+  });
+
+  it('filtragem por nome é case-insensitive', () => {
+    render(<EmployeesPage />);
+    fireEvent.change(screen.getByPlaceholderText('Buscar por nome...'), { target: { value: 'ana' } });
+    expect(screen.getByText('Ana')).toBeInTheDocument();
+    expect(screen.queryByText('Bruno')).not.toBeInTheDocument();
+  });
+
+  it('busca por substring retorna todos os matches', () => {
+    render(<EmployeesPage />);
+    // 'a' aparece em 'Ana' e 'Cida'
+    fireEvent.change(screen.getByPlaceholderText('Buscar por nome...'), { target: { value: 'a' } });
+    expect(screen.getAllByTestId('employee-card')).toHaveLength(2);
+    expect(screen.getByText('Ana')).toBeInTheDocument();
+    expect(screen.getByText('Cida')).toBeInTheDocument();
+    expect(screen.queryByText('Bruno')).not.toBeInTheDocument();
+  });
+
+  it('busca sem resultado exibe mensagem descritiva com menção a filtros', () => {
+    render(<EmployeesPage />);
+    fireEvent.change(screen.getByPlaceholderText('Buscar por nome...'), { target: { value: 'XYZXYZ' } });
+    expect(screen.getByText('Nenhum motorista encontrado para os filtros aplicados')).toBeInTheDocument();
+  });
+
+  it('busca por nome não dispara requests ao backend (fetchEmployees chamado apenas no mount)', () => {
+    render(<EmployeesPage />);
+    const callsBefore = mockStore.fetchEmployees.mock.calls.length;
+    fireEvent.change(screen.getByPlaceholderText('Buscar por nome...'), { target: { value: 'Ana' } });
+    expect(mockStore.fetchEmployees.mock.calls.length).toBe(callsBefore);
+  });
+});
+
+// ── Filtro por setor ──────────────────────────────────────────────────────────
+
+describe('EmployeesPage — filtro por setor', () => {
+  it('selecionar "Transporte Ambulância" exibe somente motoristas desse setor', () => {
+    render(<EmployeesPage />);
+    fireEvent.change(screen.getByRole('combobox', { name: /Filtrar por setor/i }), {
+      target: { value: 'Transporte Ambulância' },
+    });
+    // Ana e Cida são de Ambulância; Bruno de Hemodiálise
+    expect(screen.getAllByTestId('employee-card')).toHaveLength(2);
+    expect(screen.getByText('Ana')).toBeInTheDocument();
+    expect(screen.getByText('Cida')).toBeInTheDocument();
+    expect(screen.queryByText('Bruno')).not.toBeInTheDocument();
+  });
+
+  it('selecionar "Transporte Hemodiálise" exibe somente Bruno', () => {
+    render(<EmployeesPage />);
+    fireEvent.change(screen.getByRole('combobox', { name: /Filtrar por setor/i }), {
+      target: { value: 'Transporte Hemodiálise' },
+    });
+    expect(screen.getAllByTestId('employee-card')).toHaveLength(1);
+    expect(screen.getByText('Bruno')).toBeInTheDocument();
+  });
+
+  it('filtro de setor sem resultado exibe mensagem descritiva', () => {
+    render(<EmployeesPage />);
+    fireEvent.change(screen.getByRole('combobox', { name: /Filtrar por setor/i }), {
+      target: { value: 'Transporte Administrativo' },
+    });
+    expect(screen.getByText('Nenhum motorista encontrado para os filtros aplicados')).toBeInTheDocument();
+  });
+
+  it('selecionar "Todos os setores" restaura lista completa', () => {
+    render(<EmployeesPage />);
+    const select = screen.getByRole('combobox', { name: /Filtrar por setor/i });
+    fireEvent.change(select, { target: { value: 'Transporte Hemodiálise' } });
+    fireEvent.change(select, { target: { value: '' } });
+    expect(screen.getAllByTestId('employee-card')).toHaveLength(3);
+  });
+});
+
+// ── Combinação de filtros ─────────────────────────────────────────────────────
+
+describe('EmployeesPage — combinação nome + setor (AND)', () => {
+  it('nome "Ana" + setor "Transporte Ambulância" retorna somente Ana', () => {
+    render(<EmployeesPage />);
+    fireEvent.change(screen.getByPlaceholderText('Buscar por nome...'), { target: { value: 'Ana' } });
+    fireEvent.change(screen.getByRole('combobox', { name: /Filtrar por setor/i }), {
+      target: { value: 'Transporte Ambulância' },
+    });
+    expect(screen.getAllByTestId('employee-card')).toHaveLength(1);
+    expect(screen.getByText('Ana')).toBeInTheDocument();
+  });
+
+  it('nome "Ana" + setor "Transporte Hemodiálise" retorna resultado vazio', () => {
+    render(<EmployeesPage />);
+    fireEvent.change(screen.getByPlaceholderText('Buscar por nome...'), { target: { value: 'Ana' } });
+    fireEvent.change(screen.getByRole('combobox', { name: /Filtrar por setor/i }), {
+      target: { value: 'Transporte Hemodiálise' },
+    });
+    expect(screen.getByText('Nenhum motorista encontrado para os filtros aplicados')).toBeInTheDocument();
+  });
+});
+
+// ── Limpar filtros ────────────────────────────────────────────────────────────
+
+describe('EmployeesPage — botão Limpar filtros', () => {
+  it('botão aparece quando busca por nome está ativa', () => {
+    render(<EmployeesPage />);
+    fireEvent.change(screen.getByPlaceholderText('Buscar por nome...'), { target: { value: 'Ana' } });
+    expect(screen.getByRole('button', { name: /Limpar filtros/i })).toBeInTheDocument();
+  });
+
+  it('botão aparece quando filtro de setor está ativo', () => {
+    render(<EmployeesPage />);
+    fireEvent.change(screen.getByRole('combobox', { name: /Filtrar por setor/i }), {
+      target: { value: 'Transporte Ambulância' },
+    });
+    expect(screen.getByRole('button', { name: /Limpar filtros/i })).toBeInTheDocument();
+  });
+
+  it('clicar em "Limpar filtros" restaura a lista completa', () => {
+    render(<EmployeesPage />);
+    fireEvent.change(screen.getByPlaceholderText('Buscar por nome...'), { target: { value: 'Ana' } });
+    fireEvent.change(screen.getByRole('combobox', { name: /Filtrar por setor/i }), {
+      target: { value: 'Transporte Ambulância' },
+    });
+    expect(screen.getAllByTestId('employee-card')).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /Limpar filtros/i }));
+    expect(screen.getAllByTestId('employee-card')).toHaveLength(3);
+    expect(screen.queryByRole('button', { name: /Limpar filtros/i })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Contexto

Issue #74 — busca/filtro de motoristas na EmployeesPage.

A `EmployeesPage` já tinha uma busca de texto unificada (nome/cargo/setor). Esta PR a substitui por dois filtros independentes conforme especificado na issue: campo de nome (substring) + dropdown de setor (match exato), combinados com lógica AND.

## Mudanças

### `EmployeesPage.jsx`
- `filterSetor` state separado do `search` (nome)
- `hasFilters` derivado de ambos os estados — controla visibilidade do botão "Limpar filtros"
- `filtered`: lógica AND → `matchName && matchSetor`
- `SETORES` constante com os 3 valores válidos do domínio (espelha `SETORES_VALIDOS` do backend)
- `select` com `aria-label="Filtrar por setor"` (acessibilidade)
- Mensagem de vazio: `"Nenhum motorista encontrado para os filtros aplicados"` (filtros ativos) vs `"Nenhum motorista cadastrado"` (sem filtros)

### `EmployeesPage.test.jsx` (novo — 18 testes)
Cobre todos os critérios de aceite:
- Renderização base (4 testes)
- Busca por nome: tempo real, case-insensitive, substring, vazio, sem request extra (5 testes)
- Filtro por setor: Ambulância, Hemodiálise, sem resultado, reset (4 testes)
- Combinação nome + setor (AND): match e sem resultado (2 testes)
- Limpar filtros: visibilidade, restauração, desaparecimento do botão (3 testes)

## Plano de teste

Testes automatizados — 144/144 passando localmente:
```
Test Files  8 passed (8)
Tests      144 passed (144)
Duration   3.23s
```

Filtragem client-side verificada: o teste "busca por nome não dispara requests ao backend" confirma que `fetchEmployees` não é chamado ao digitar no campo de busca.

Desenvolvedor Pleno — closes #74