### PR TITLE
fix(generator): recovery NOTURNO — semanas 42h com dias consecutivos bloqueados

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -439,6 +439,46 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
         }
       }
 
+      // Recuperação NOTURNO: se selectedWork bloqueou turnos por restrição de descanso (12h < 24h),
+      // tenta dias de selectedOff que tenham descanso adequado para completar a meta semanal.
+      // Aplicado apenas a NOTURNO: garante que semanas 42h recebam 3 plantões (não apenas 2)
+      // quando selectOffDays seleciona dias consecutivos bloqueados. Issue #86.
+      // DIURNO não precisa: limite semanal é sempre 36h e correctHours já cobre o déficit.
+      if (isNoturno) {
+        const placedThisWeek = entries.filter(
+          (e) => !e.is_day_off && e.shift_type_id && e.date >= week[0] && e.date <= week[week.length - 1]
+        ).length;
+        if (placedThisWeek < actualWorkInWeek) {
+          const needed = actualWorkInWeek - placedThisWeek;
+          let recovered = 0;
+          const convertedFromOff = new Set();
+          for (const date of selectedOff) {
+            if (recovered >= needed) break;
+            if (lockedDates.has(date) || vacationDatesForEmp.has(date)) continue;
+            const shift = selectShift(twelveHourShifts, preferredShift, lastShiftEnd, lastShiftName, consecutiveHours, date);
+            if (!shift) continue;
+            entries.push({ employee_id: employee.id, shift_type_id: shift.id, date, is_day_off: 0, is_locked: 0, notes: null });
+            totalHours += shift.duration_hours;
+            const shiftStart = computeShiftStart(date, shift);
+            const restHours = lastShiftEnd
+              ? (shiftStart - lastShiftEnd) / (1000 * 60 * 60)
+              : Infinity;
+            consecutiveHours = restHours === 0
+              ? consecutiveHours + shift.duration_hours
+              : shift.duration_hours;
+            lastShiftEnd = computeShiftEnd(date, shift);
+            lastShiftName = shift.name;
+            convertedFromOff.add(date);
+            recovered++;
+          }
+          // Remove dias convertidos de selectedOff para não serem adicionados como folga abaixo
+          for (const date of convertedFromOff) {
+            const idx = selectedOff.indexOf(date);
+            if (idx !== -1) selectedOff.splice(idx, 1);
+          }
+        }
+      }
+
       for (const date of selectedOff) {
         entries.push({ employee_id: employee.id, shift_type_id: null, date, is_day_off: 1, is_locked: 0, notes: null });
         consecutiveHours = 0;

--- a/backend/src/tests/noturno42h.test.js
+++ b/backend/src/tests/noturno42h.test.js
@@ -202,6 +202,47 @@ describe('Regra #65 — turno extra de 6h respeita descanso mínimo de 24h (ou e
   });
 });
 
+// ── Teste 5: Bug #86 — semanas 42h devem ter 3 NOTURNOs (não apenas 2) ────────
+//
+// Cenário do bug: selectOffDays com offset=1 seleciona {Feb3,Feb4,Feb5} como work.
+// Feb4 (12h rest de Feb3) é bloqueado → apenas 2 NOTURNOs colocados = 24h na semana.
+// Com o fix (recovery step NOTURNO), o gerador recupera um dia de selectedOff
+// (Feb7) que tem ≥24h rest → 3 NOTURNOs = 36h + 1 extra 6h = 42h.
+
+describe('Bug #86 — recovery NOTURNO: 3 plantões em semanas 42h com dias consecutivos', () => {
+  it('FEV_WEEK1 (42h): motorista NOTURNO tem exatamente 3 plantões NOTURNO (não apenas 2)', async () => {
+    // empId=1 → workStart=1%7=1 → workIndices={Feb3,Feb4,Feb5} (consecutivos).
+    // Feb4 é bloqueado por descanso 12h de Feb3. Sem recovery → 2 NOTURNOs.
+    // Com recovery → Feb7 adicionado de selectedOff → 3 NOTURNOs.
+    const { emp } = await createNoturnoEmployee('Noturno Bug86');
+
+    const genRes = await request(app).post('/api/schedules/generate').send(FEV);
+    expect(genRes.status).toBe(200);
+
+    const schedRes = await request(app).get(`/api/schedules?month=${FEV.month}&year=${FEV.year}`);
+    const allEntries = schedRes.body.entries;
+
+    const week1Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK1);
+    const noturnoEntries = week1Work.filter((e) => e.shift_name === 'Noturno');
+
+    expect(noturnoEntries).toHaveLength(3);
+  });
+
+  it('FEV_WEEK2 (42h): motorista NOTURNO tem exatamente 3 plantões NOTURNO', async () => {
+    const { emp } = await createNoturnoEmployee('Noturno Bug86 W2');
+
+    await request(app).post('/api/schedules/generate').send(FEV);
+
+    const schedRes = await request(app).get(`/api/schedules?month=${FEV.month}&year=${FEV.year}`);
+    const allEntries = schedRes.body.entries;
+
+    const week2Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK2);
+    const noturnoEntries = week2Work.filter((e) => e.shift_name === 'Noturno');
+
+    expect(noturnoEntries).toHaveLength(3);
+  });
+});
+
 // ── Teste 4: Motorista DIURNO não recebe extra na semana 42h ─────────────────
 
 describe('Regra #65 — motorista DIURNO não recebe turno extra de 6h', () => {


### PR DESCRIPTION
## Problema (Bug #86)

`selectOffDays` usa rotação por `employee.id` para distribuir folgas. Em certos offsets, os dias selecionados como work são consecutivos (ex: Seg, Ter, Qua). NOTURNO entre dias consecutivos gera 12h de descanso (abaixo do mínimo de 24h), bloqueando o segundo dia:

- Seg NOTURNO (19:00–07:00) → Ter NOTURNO bloqueado (12h rest < 24h)
- Resultado: apenas **2 NOTURNOs** na semana em vez de **3** → **24h** trabalhadas em semana 42h (meta: 36h+6h=42h)

Reprodução: empId=1 em Fev/2025 Semana 1 → workIndices={Seg,Ter,Qua} → Ter bloqueado → 2 NOTURNOs.

## Fix

Recovery step exclusivo para NOTURNO, executado após o loop de `selectedWork`:

```javascript
if (isNoturno) {
  const placedThisWeek = entries.filter(...).length;
  if (placedThisWeek < actualWorkInWeek) {
    // tenta dias de selectedOff com descanso adequado
    for (const date of selectedOff) { ... }
  }
}
```

DIURNO não está incluído: limite semanal é sempre 36h e `correctHours` já resolve o déficit sem risco de cascata no `lastShiftEnd` entre semanas.

## Plano de teste

1. 2 novos testes unitários em `noturno42h.test.js` verificam 3 NOTURNOs em semanas 42h (FEV_WEEK1 e FEV_WEEK2) — falhariam no estado do bug
2. Suite completa de regressão para garantir que `sem_motorista_forcado = 0` permanece intacto
3. `offDayDistribution.test.js` garante que a distribuição de folgas não regrediu

## Logs de execução

```
✓ noturno42h.test.js (7 tests) 955ms
  ✓ Bug #86: FEV_WEEK1 (42h): motorista NOTURNO tem exatamente 3 plantões NOTURNO
  ✓ Bug #86: FEV_WEEK2 (42h): motorista NOTURNO tem exatamente 3 plantões NOTURNO

Test Files  14 passed (14)
Tests       199 passed (199)   ← +2 testes de regressão Bug #86
Test Files   8 passed  (8)
Tests       144 passed (144)

Total: 343/343 testes passando
```

## Taxa de sucesso

**343/343** testes passando (199 backend + 144 frontend).

Closes #86