### PR TITLE
fix(generator): DIURNO nao recebe turno Noturno - bug #87

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -415,8 +415,14 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
       const selectedOff = selectOffDays(freeInWeek, actualOffInWeek, employee.id);
       const selectedWork = freeInWeek.filter((d) => !selectedOff.includes(d));
 
+      // Bug #87: para motoristas com turno preferido EXPLICITAMENTE configurado como não-NOTURNO
+      // (ex: DIURNO), não fazer fallback para NOTURNO quando o turno preferido é bloqueado.
+      // DIURNO bloqueado → folga, não NOTURNO. Evita células DIURNO+NOTURNO adjacentes na UI.
+      // NOTURNO, sem-preferência (preferred_shift_id=null) e padrão: usam todos os 12h.
+      const shiftsForSelect = (rules.preferred_shift_id && !isNoturno) ? [preferredShift] : twelveHourShifts;
+
       for (const date of selectedWork) {
-        const shift = selectShift(twelveHourShifts, preferredShift, lastShiftEnd, lastShiftName, consecutiveHours, date);
+        const shift = selectShift(shiftsForSelect, preferredShift, lastShiftEnd, lastShiftName, consecutiveHours, date);
         if (shift) {
           entries.push({ employee_id: employee.id, shift_type_id: shift.id, date, is_day_off: 0, is_locked: 0, notes: null });
           totalHours += shift.duration_hours;
@@ -863,6 +869,21 @@ function enforceNocturnalCoverage(db, employees, employeeSectorsMap, dates, notu
   // Agrupa datas em semanas (Dom–Sáb) para verificação do limite semanal CLT
   const weeks = buildWeeks(dates);
 
+  // Cache do turno preferido por employee_id — usado para não forçar NOTURNO em motoristas DIURNO.
+  // Bug #87: enforceNocturnalCoverage não verificava preferred_shift antes de converter.
+  const preferredShiftNameByEmp = {};
+  for (const emp of employees) {
+    const row = db
+      .prepare(
+        `SELECT st.name as shift_name
+         FROM employee_rest_rules err
+         LEFT JOIN shift_types st ON err.preferred_shift_id = st.id
+         WHERE err.employee_id = ?`
+      )
+      .get(emp.id);
+    preferredShiftNameByEmp[emp.id] = row?.shift_name ?? null;
+  }
+
   /**
    * Retorna os limites da semana à qual `date` pertence.
    */
@@ -935,6 +956,10 @@ function enforceNocturnalCoverage(db, employees, employeeSectorsMap, dates, notu
         if (fixed >= needed) break;
         const setores = employeeSectorsMap[emp.id] || [];
         if (!setores.includes(SETOR_AMBUL)) continue;
+        // Bug #87: só converte motoristas cujo turno preferido é NOTURNO (ou sem preferência).
+        // Motoristas DIURNO não devem ser forçados a NOTURNO — viola o turno contratado.
+        const prefName = preferredShiftNameByEmp[emp.id];
+        if (prefName && prefName !== SHIFT_NOTURNO_NAME) continue;
         // Regra 12: seg_sex nunca trabalha Sábado (dow=6); domingo já tem required=0 acima.
         if (emp.work_schedule === 'seg_sex' && dow === 6) continue;
         const entry = entryByEmp[emp.id];

--- a/backend/src/tests/scheduleRules.test.js
+++ b/backend/src/tests/scheduleRules.test.js
@@ -193,4 +193,35 @@ describe('Regra 5 — cobertura diurna mínima (Regra 16)', () => {
       expect(shiftById[e.shift_type_id]).toBe(e.shift_name);
     });
   });
+
+  it('Bug #87: motorista DIURNO (Ambulância) não recebe turno Noturno pelo enforceNocturnalCoverage', async () => {
+    // enforceNocturnalCoverage não verificava preferred_shift antes de converter.
+    // Um motorista DIURNO (Ambulância) poderia ser convertido para NOTURNO para cobrir
+    // requisito de cobertura noturna, gerando células adjacentes Diurno+Noturno na UI.
+    // Fix: guard `prefName && prefName !== SHIFT_NOTURNO_NAME` → skip DIURNO employees.
+    const db = freshDb();
+
+    const shiftsRes = await request(app).get('/api/shift-types');
+    const diurnoId = shiftsRes.body.find((s) => s.name === 'Diurno')?.id;
+    expect(diurnoId).toBeDefined();
+
+    // Cria 1 motorista DIURNO (Ambulância) — sem NOTURNO disponível para cobertura.
+    // enforceNocturnalCoverage tentará converter esse motorista antes do fix.
+    const empRes = await request(app).post('/api/employees').send({
+      name: 'Diurno Ambul Bug87',
+      setores: ['Transporte Ambulância'],
+      restRules: { preferred_shift_id: diurnoId, notes: null },
+    });
+    expect(empRes.status).toBe(201);
+    const empId = empRes.body.id;
+
+    await request(app).post('/api/schedules/generate').send({ month: 1, year: 2025 });
+
+    const schedRes = await request(app).get('/api/schedules?month=1&year=2025');
+    const empEntries = schedRes.body.entries.filter((e) => e.employee_id === empId && !e.is_day_off);
+
+    // Nenhuma entrada de trabalho deve ter turno Noturno
+    const noturnoEntries = empEntries.filter((e) => e.shift_name === 'Noturno');
+    expect(noturnoEntries).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Problema

Bug #87: motorista com preferred_shift=Diurno recebia turnos Noturno em dois cenarios:

1. **enforceNocturnalCoverage** - ao preencher cobertura noturna de Ambulancia, nao verificava o preferred_shift do candidato antes de converter sua folga em Noturno.
2. **Gerador (non-ADM path)** - quando o turno Diurno era bloqueado por descanso insuficiente (12h < 24h MIN_REST), selectShift fazia fallback para Noturno (que tem exatamente 24h de rest = permitido).

Resultado: celula DIURNO em um dia + NOTURNO no dia seguinte na UI.

## Solucao

### 1. enforceNocturnalCoverage
Cache preferredShiftNameByEmp + guard por candidato:
- Busca o nome do turno preferido de cada motorista antes do loop
- Guard: se prefName exists e != NOTURNO -> skip candidato

### 2. Gerador
shiftsForSelect restringe candidatos quando preferred_shift_id foi EXPLICITAMENTE configurado:
- rules.preferred_shift_id = campo BD (null para sem preferencia)
- preferredShift = tem fallback para Diurno (default) - nao pode ser usado na condicao
- Motoristas sem preferred_shift_id (default) continuam usando twelveHourShifts - preserva comportamento "Regra 1" (NOTURNO como fallback para empregados sem preferencia)

## Evidencia - testes

```
Test Files  14 passed (14)
Tests       198 passed (198)
```

Teste de regressao adicionado em scheduleRules.test.js:
- **Bug #87**: 1 motorista DIURNO (Ambulancia) -> 0 entradas Noturno apos geracao Jan/2025

Regra 1 (padrao de 12h - NOTURNO) continua passando.

## Arquivos alterados
- backend/src/services/scheduleGenerator.js - 2 locais (enforcement + gerador)
- backend/src/tests/scheduleRules.test.js - 1 teste de regressao