### PR TITLE
fix(generator): recovery usa virtual rest cross-semana — issue #94

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -513,13 +513,54 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
             for (const date of selectedOff) {
               if (recovered >= needed) break;
               if (lockedDates.has(date) || vacationDatesForEmp.has(date)) continue;
-              const shift = selectShift(shiftsForSelect, preferredShift, lastShiftEnd, lastShiftName, consecutiveHours, date);
+
+              // Fix #94: quando o lastShiftEnd global está no futuro em relação ao candidato
+              // (caso cross-semana: isDiurno42h colocou turno no fim da semana anterior,
+              // fazendo lastShiftEnd apontar para além do candidato de selectedOff),
+              // usa virtual lastShiftEnd = último turno cronologicamente ANTES deste candidato.
+              // Guarda crítica: se não houver preceding (candidato vem antes de todo trabalho
+              // já feito, i.e., data retroativa), manter lastShiftEnd global — o rest negativo
+              // fará o selectShift rejeitar corretamente, evitando colocação retroativa.
+              let effectiveLastShiftEnd = lastShiftEnd;
+              let effectiveLastShiftName = lastShiftName;
+              let effectiveConsecutiveHours = consecutiveHours;
+
+              if (lastShiftEnd) {
+                const candidateShiftForCheck = shiftsForSelect[0] || preferredShift;
+                if (candidateShiftForCheck) {
+                  const candidateStart = computeShiftStart(date, candidateShiftForCheck);
+                  if (candidateStart && lastShiftEnd > candidateStart) {
+                    // O lastShiftEnd global está além do candidateStart: cross-semana isDiurno42h.
+                    // Calcular virtual rest a partir do último turno ANTERIOR a este candidato.
+                    const precedingWork = entries
+                      .filter(e => !e.is_day_off && e.shift_type_id && e.date < date)
+                      .sort((a, b) => (a.date > b.date ? 1 : -1));
+                    const preceding = precedingWork.length ? precedingWork[precedingWork.length - 1] : null;
+                    if (preceding) {
+                      // preceding existe: usar virtual rest (o caso correto do fix #94)
+                      effectiveLastShiftEnd = computeShiftEnd(preceding.date, shiftMap[preceding.shift_type_id]);
+                      effectiveLastShiftName = shiftMap[preceding.shift_type_id]?.name ?? null;
+                      effectiveConsecutiveHours = shiftMap[preceding.shift_type_id]?.duration_hours ?? 0;
+                    }
+                    // Se preceding === null: manter effectiveLastShiftEnd = lastShiftEnd global.
+                    // selectShift verá rest < 0 e rejeitará → candidato retroativo pulado corretamente.
+                  }
+                }
+              }
+
+              const shift = selectShift(shiftsForSelect, preferredShift, effectiveLastShiftEnd, effectiveLastShiftName, effectiveConsecutiveHours, date);
               if (!shift) continue;
+              // Verificar restrição de descanso PARA FRENTE (turno seguinte já colocado).
+              // Necessário quando o virtual rest colocou este candidato em data anterior
+              // a turnos já existentes no array entries — hasAdequateRest verifica ambos lados.
+              const tempEntry = { date, is_day_off: 0, shift_type_id: shift.id, is_locked: 0 };
+              if (!hasAdequateRest(entries, tempEntry, shift, shiftMap)) continue;
+              if (wouldExceedConsecutive(entries, tempEntry)) continue;
               entries.push({ employee_id: employee.id, shift_type_id: shift.id, date, is_day_off: 0, is_locked: 0, notes: null });
               totalHours += shift.duration_hours;
               const shiftStart = computeShiftStart(date, shift);
-              const restHours = lastShiftEnd
-                ? (shiftStart - lastShiftEnd) / (1000 * 60 * 60)
+              const restHours = effectiveLastShiftEnd
+                ? (shiftStart - effectiveLastShiftEnd) / (1000 * 60 * 60)
                 : Infinity;
               consecutiveHours = restHours === 0
                 ? consecutiveHours + shift.duration_hours

--- a/backend/src/tests/recoveryVirtualRest.test.js
+++ b/backend/src/tests/recoveryVirtualRest.test.js
@@ -1,0 +1,118 @@
+/**
+ * test(generator): regressão fix #94 — recovery usa virtual rest cross-semana
+ *
+ * Desenvolvedor Pleno
+ *
+ * Bug #94: no else-branch do gerador (semanas 36h), o bloco de recovery falhava
+ * quando a semana anterior (isDiurno42h) colocava um turno no último dia da semana
+ * (Sáb), avançando lastShiftEnd para além dos candidatos de selectedOff da semana
+ * seguinte. O rest calculado pelo selectShift era negativo → todos os candidatos
+ * pulados → semana 36h gerava somente 24h (2 turnos ao invés de 3).
+ *
+ * Fix: recovery calcula virtual lastShiftEnd = último turno cronologicamente
+ * anterior ao candidato. Guarda: se não houver preceding (data retroativa),
+ * mantém o lastShiftEnd global (rest negativo → rejeição correta).
+ * hasAdequateRest verifica restrições para frente (turno seguinte).
+ *
+ * Cenário de teste:
+ *   Motorista DIURNO, Transporte Ambulância (preferred_shift_id = null, não-ADM).
+ *   cycle_start=Jan/2025 → fase 1 → padrão ['36h','42h','42h','36h','36h'] em Jan/2025.
+ *   Jan/2025 (5 semanas):
+ *     Week 0: 36h (4 dias: Jan 1–4)
+ *     Week 1: 42h → isDiurno42h (Jan 5–11)
+ *     Week 2: 42h → isDiurno42h (Jan 12–18) — último turno = Sáb Jan 18
+ *     Week 3: 36h → else-branch (Jan 19–25) — Jan 19 Dom pode ser bloqueado (12h rest)
+ *     Week 4: 36h → else-branch (Jan 26–31)
+ *
+ * Antes do fix: Week 3 gerava somente 2×12h = 24h (recovery falhava).
+ * Depois do fix: Week 3 gera 3×12h = 36h (recovery usa virtual rest).
+ *
+ * Verificações:
+ *   1. Total de horas mensal entre 144h e 192h.
+ *   2. Week 3 (Jan 19–25) com pelo menos 36h (3 turnos de 12h).
+ *   3. Nenhum par consecutivo de turnos totaliza >= 24h (Regra 2).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../app.js';
+import { freshDb } from './helpers.js';
+
+beforeEach(() => freshDb());
+
+const JAN2025 = { month: 1, year: 2025 };
+
+describe('Fix #94 — recovery virtual rest cross-semana', () => {
+  it('semana 36h após isDiurno42h gera 36h (3 turnos 12h) mesmo quando Dom é bloqueado por rest=12h', async () => {
+    // Criar motorista DIURNO (Ambulância, cycle_start=Jan/2025 → fase 1)
+    const empRes = await request(app)
+      .post('/api/employees')
+      .send({
+        name: 'Alex Fix94',
+        setores: ['Transporte Ambulância'],
+        cycle_start_month: 1,
+        cycle_start_year: 2025,
+      });
+    expect(empRes.status).toBe(201);
+    const empId = empRes.body.id;
+
+    // Gerar escala de Janeiro/2025
+    const genRes = await request(app)
+      .post('/api/schedules/generate')
+      .send(JAN2025);
+    expect(genRes.status).toBe(200);
+    expect(genRes.body.success).toBe(true);
+
+    // Buscar entries geradas
+    const schedRes = await request(app)
+      .get(`/api/schedules?month=${JAN2025.month}&year=${JAN2025.year}`);
+    expect(schedRes.status).toBe(200);
+
+    const allEntries = schedRes.body.entries.filter((e) => e.employee_id === empId);
+
+    // ── Verificação 1: total mensal entre 144h e 192h ────────────────────────
+    const totalHours = allEntries.reduce(
+      (sum, e) => (e.is_day_off ? sum : sum + (e.duration_hours || 0)),
+      0
+    );
+    expect(totalHours).toBeGreaterThanOrEqual(144);
+    expect(totalHours).toBeLessThanOrEqual(192);
+
+    // ── Verificação 2: Week 3 (Jan 19–25) tem pelo menos 36h ────────────────
+    // Phase 1, Week 3 = 36h → expected 3 turnos de 12h = 36h.
+    // Antes do fix, a semana gerava 24h (2 turnos) por causa do bug no recovery.
+    const week3Entries = allEntries.filter(
+      (e) => e.date >= '2025-01-19' && e.date <= '2025-01-25'
+    );
+    const week3Hours = week3Entries.reduce(
+      (sum, e) => (e.is_day_off ? sum : sum + (e.duration_hours || 0)),
+      0
+    );
+    expect(week3Hours).toBeGreaterThanOrEqual(36);
+
+    // ── Verificação 3: Regra 2 — nenhum par consecutivo totaliza >= 24h ─────
+    const workEntries = allEntries
+      .filter((e) => !e.is_day_off && e.start_time && e.duration_hours)
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    let consecutiveHours = 0;
+    let lastEnd = null;
+
+    for (const entry of workEntries) {
+      const [h, m] = entry.start_time.split(':').map(Number);
+      const start = new Date(
+        `${entry.date}T${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:00`
+      );
+      const restHours = lastEnd ? (start - lastEnd) / (1000 * 60 * 60) : Infinity;
+
+      if (restHours === 0) {
+        consecutiveHours += entry.duration_hours;
+      } else {
+        consecutiveHours = entry.duration_hours;
+      }
+
+      expect(consecutiveHours).toBeLessThan(24);
+      lastEnd = new Date(start.getTime() + entry.duration_hours * 60 * 60 * 1000);
+    }
+  });
+});


### PR DESCRIPTION
## Resumo

- **Bug**: no `else-branch` (semanas 36h), o bloco de recovery falhava quando a semana anterior (`isDiurno42h`) colocava um turno no último dia da semana (Sáb), fazendo `lastShiftEnd` avançar para além dos candidatos de `selectedOff` da semana seguinte. Rest calculado era negativo → todos os candidatos pulados → semana gerava 24h (2 turnos) em vez de 36h (3 turnos).
- **Fix**: recovery calcula `virtual lastShiftEnd` = último turno cronologicamente ANTES do candidato, apenas quando `lastShiftEnd > candidateStart` (caso cross-semana). Guarda crítica: se `preceding === null` (data retroativa), mantém o `lastShiftEnd` global — rest negativo preserva rejeição correta. `hasAdequateRest` verifica restrições forward (turno seguinte já colocado).
- **Teste**: `recoveryVirtualRest.test.js` — 1 teste de integração: DIURNO Ambulância, cycle_start=Jan/2025 (fase 1), Jan/2025 — verifica Week 3 (Jan 19–25) ≥ 36h e Regra 2 (sem 24h consecutivas).

## Detalhes técnicos

**Cenário de falha** (antes do fix):
- Week 2 (42h, isDiurno42h): último turno = Jan 18 (Sáb) Diurno, `lastShiftEnd = Jan 18 19:00`
- Week 3 (36h, else-branch): `selectOffDays(empOffset=1)` → `selectedWork = [Jan 20, Jan 21, Jan 22]`
  - Jan 21: rest = 12h → bloqueado → FOLGA; `lastShiftEnd` avança para Jan 22 19:00
  - `placed = 2 < actualWorkInWeek = 3` → recovery necessário
- Recovery tentava `selectedOff = [Jan 19, Jan 23, Jan 24, Jan 25]`:
  - Jan 19: `lastShiftEnd (Jan 22 19:00) > candidateStart (Jan 19 07:00)` — rest negativo → pulado
  - Jan 23+: rest normal mas recovered < needed → semana ficava com 24h

**Fix aplicado** em `backend/src/services/scheduleGenerator.js` (~linhas 517–558):

```js
// Quando lastShiftEnd > candidateStart (cross-semana isDiurno42h):
const precedingWork = entries.filter(...e.date < date...).sort(...);
const preceding = precedingWork.length ? precedingWork[precedingWork.length - 1] : null;
if (preceding) {
  effectiveLastShiftEnd = computeShiftEnd(preceding.date, shiftMap[preceding.shift_type_id]);
  // ... usa virtual rest correto
}
// preceding === null → mantém global → rest < 0 → skip correto (data retroativa)
```

Após `selectShift`, verifica `hasAdequateRest` (restrições forward) e `wouldExceedConsecutive`.

## Plano de testes

- [x] `npm test` completo: **206 backend + 144 frontend passando**
- [x] Novo teste de regressão: `recoveryVirtualRest.test.js` (1 teste)
- [x] Regra 2 (24h consecutivas) mantida ✅
- [x] Regra 13 (total 144h–192h) mantida ✅
- [x] Sem regressão em `cycleMonth.test.js`, `noturno42h.test.js`, `scheduleRules.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)