### PR TITLE
fix(generator): semanas parciais no inicio do mes nao recebem meta CLT

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -270,6 +270,13 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
     employee.cycle_start_year ?? new Date().getFullYear(),
     genMonth, genYear
   );
+  // Issue #96: Detectar semanas parciais (< 7 dias) no início e fim do mês.
+  // Meses que não começam num domingo têm uma semana inicial parcial.
+  // O índice CLT (wi) deve contar apenas a partir da primeira semana COMPLETA.
+  // Semanas parciais não recebem meta CLT — escalamos o que couber com rest ≥ 24h.
+  const firstWeekIsPartial = weeks.length > 0 && weeks[0].length < 7;
+  // cltWeekOffset: quantas semanas parciais há antes das semanas completas (0 ou 1)
+  const cltWeekOffset = firstWeekIsPartial ? 1 : 0;
 
   let totalHours = 0;
   let lastShiftEnd = null;
@@ -328,7 +335,13 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
         lastShiftName = null;
       }
 
-      const maxTurnosNaSemana = getWeekTypeFromPhase(effectiveCycleMonth, wi) === '36h' ? 3 : 4;
+      // Issue #96: wi CLT começa em 0 na primeira semana COMPLETA.
+      // Se a semana atual é parcial (cltWi < 0), escalar sem meta CLT (usa máx 3 turnos conservador).
+      const cltWi = wi - cltWeekOffset;
+      const weekTypeAdm = cltWi >= 0
+        ? getWeekTypeFromPhase(effectiveCycleMonth, cltWi)
+        : '36h'; // semana parcial: sem meta CLT — usa 3 turnos como padrão conservador
+      const maxTurnosNaSemana = weekTypeAdm === '36h' ? 3 : 4;
       const maxWorkInWeek = Math.min(freeInWeek.length, maxTurnosNaSemana);
       const actualOffInWeek = freeInWeek.length - Math.max(0, maxWorkInWeek);
 
@@ -406,7 +419,12 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
       // Seleciona 4 posições com espaçamento de 2 dias (índices 0,2,4,6 em available),
       // garantindo rest ≥ 36h entre qualquer par DIURNO(19:00)→DIURNO(07:00) do próximo dia.
       // Rotaciona qual posição recebe o turno extra de 6h via employee.id % 4.
-      const weekType = getWeekTypeFromPhase(effectiveCycleMonth, wi);
+      // Issue #96: wi CLT começa em 0 na primeira semana COMPLETA.
+      // Semanas parciais (cltWi < 0) → '36h' como fallback (3 plantões, sem extra 6h).
+      const cltWi = wi - cltWeekOffset;
+      const weekType = cltWi >= 0
+        ? getWeekTypeFromPhase(effectiveCycleMonth, cltWi)
+        : '36h'; // semana parcial: sem meta CLT — sem turno extra 6h
       const isDiurno42h = !isNoturno && weekType === '42h';
 
       if (isDiurno42h) {
@@ -644,10 +662,15 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
     });
   }
 
-  const weekClassifications = weeks.map((_, wi) => ({
-    weekIndex: wi,
-    type: getWeekTypeFromPhase(effectiveCycleMonth, wi),
-  }));
+  // Issue #96: semanas parciais recebem label 'partial', semanas CLT usam cltWi.
+  const weekClassifications = weeks.map((week, wi) => {
+    const cltWi = wi - cltWeekOffset;
+    return {
+      weekIndex: wi,
+      type: cltWi >= 0 ? getWeekTypeFromPhase(effectiveCycleMonth, cltWi) : 'partial',
+      partial: week.length < 7,
+    };
+  });
 
   return { employee: employee.name, hours: finalHours, weekClassifications };
 }
@@ -1491,15 +1514,21 @@ export function correctHours(
 
   // Monta mapa semana → {weekStart, weekEnd, weekIndex, weekType, cltLimit}
   // para verificação do limite CLT por semana em conversões de folga→trabalho.
+  // Issue #96: semanas parciais (< 7 dias) usam '42h' como fallback conservador —
+  // não remover entries de semanas parciais que estão naturalmente abaixo do limite.
+  const firstWeekIsPartialCH = weeks.length > 0 && weeks[0].length < 7;
+  const cltWeekOffsetCH = firstWeekIsPartialCH ? 1 : 0;
   const weekMeta = weeks.map((week, wi) => {
-    const weekType = effectiveCycleMonth !== null
-      ? getWeekTypeFromPhase(effectiveCycleMonth, wi)
-      : '42h'; // fallback conservador sem contexto de fase
+    const cltWiCH = wi - cltWeekOffsetCH;
+    const weekType = (effectiveCycleMonth !== null && cltWiCH >= 0)
+      ? getWeekTypeFromPhase(effectiveCycleMonth, cltWiCH)
+      : '42h'; // fallback conservador: semanas parciais ou sem contexto de fase
     return {
       weekStart: week[0],
       weekEnd: week[week.length - 1],
       weekIndex: wi,
       weekType,
+      weekDays: week.length,
       cltLimit: getWeekLimitHours(isAdm, isNoturno, weekType),
     };
   });

--- a/backend/src/tests/noturno42h.test.js
+++ b/backend/src/tests/noturno42h.test.js
@@ -95,7 +95,7 @@ async function createDiurnoEmployee(name, cycleStartMonth = 2, cycleStartYear = 
 // ── Teste 1: Semana 36h — sem turno extra de 6h ───────────────────────────────
 
 describe('Regra #65 — semana 36h: NOTURNO sem turno extra', () => {
-  it('motorista NOTURNO em semana 36h (FEV_WEEK3 e FEV_WEEK4) não recebe turno extra de 6h', async () => {
+  it('motorista NOTURNO em semana 36h (FEV_WEEK1 e FEV_WEEK4) não recebe turno extra de 6h', async () => {
     const { emp } = await createNoturnoEmployee('Noturno 36h');
 
     const genRes = await request(app).post('/api/schedules/generate').send(FEV);
@@ -105,14 +105,14 @@ describe('Regra #65 — semana 36h: NOTURNO sem turno extra', () => {
     const allEntries = schedRes.body.entries;
 
     // Semanas 36h: nenhum turno de 6h
-    const week3Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK3);
+    const week1Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK1); // fix #96: cltWi=0 -> 36h
     const week4Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK4);
 
-    const sixHourIn36 = [...week3Work, ...week4Work].filter((e) => e.duration_hours === 6);
+    const sixHourIn36 = [...week1Work, ...week4Work].filter((e) => e.duration_hours === 6);
     expect(sixHourIn36).toHaveLength(0);
 
     // Todos os turnos de trabalho nas semanas 36h são de 12h (NOTURNO)
-    const allWork36 = [...week3Work, ...week4Work];
+    const allWork36 = [...week1Work, ...week4Work];
     allWork36.forEach((e) => {
       expect(e.duration_hours).toBe(12);
     });
@@ -122,7 +122,7 @@ describe('Regra #65 — semana 36h: NOTURNO sem turno extra', () => {
 // ── Teste 2: Semana 42h — 1 turno extra de 6h ────────────────────────────────
 
 describe('Regra #65 — semana 42h: NOTURNO com 1 turno extra de 6h', () => {
-  it('motorista NOTURNO em semana 42h (FEV_WEEK1) tem exatamente 1 turno de 6h (Manhã ou Tarde)', async () => {
+  it('motorista NOTURNO em semana 42h (FEV_WEEK2) tem exatamente 1 turno de 6h (Manhã ou Tarde)', async () => {
     const { emp } = await createNoturnoEmployee('Noturno 42h');
 
     const genRes = await request(app).post('/api/schedules/generate').send(FEV);
@@ -131,8 +131,8 @@ describe('Regra #65 — semana 42h: NOTURNO com 1 turno extra de 6h', () => {
     const schedRes = await request(app).get(`/api/schedules?month=${FEV.month}&year=${FEV.year}`);
     const allEntries = schedRes.body.entries;
 
-    const week1Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK1);
-    const sixHourEntries = week1Work.filter((e) => e.duration_hours === 6);
+    const week2Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK2); // fix #96: cltWi=1 -> 42h
+    const sixHourEntries = week2Work.filter((e) => e.duration_hours === 6);
 
     // Exatamente 1 turno de 6h na semana 42h
     expect(sixHourEntries).toHaveLength(1);
@@ -174,7 +174,7 @@ describe('Regra #65 — turno extra de 6h respeita descanso mínimo de 24h (ou e
 
     // Encontra o turno extra de 6h em FEV_WEEK1
     const extraEntry = allEntries.find(
-      (e) => e.employee_id === emp.id && FEV_WEEK1.includes(e.date) && e.duration_hours === 6
+      (e) => e.employee_id === emp.id && FEV_WEEK2.includes(e.date) && e.duration_hours === 6 // fix #96: FEV_WEEK2 cltWi=1 -> 42h
     );
     expect(extraEntry).toBeDefined();
 
@@ -249,7 +249,7 @@ describe('Bug #86 — recovery NOTURNO: 3 plantões em semanas 42h com dias cons
 // aplica-se a NOTURNO e DIURNO. Anterior: exclusivo do NOTURNO (#65).
 
 describe('Regra #90 — motorista DIURNO recebe turno extra de 6h em semana 42h', () => {
-  it('motorista DIURNO em semana 42h (FEV_WEEK1) tem exatamente 1 turno de 6h (Manhã ou Tarde)', async () => {
+  it('motorista DIURNO em semana 42h (FEV_WEEK2) tem exatamente 1 turno de 6h // fix #96 (Manhã ou Tarde)', async () => {
     const { emp } = await createDiurnoEmployee('Diurno 42h');
 
     const genRes = await request(app).post('/api/schedules/generate').send(FEV);
@@ -258,8 +258,8 @@ describe('Regra #90 — motorista DIURNO recebe turno extra de 6h em semana 42h'
     const schedRes = await request(app).get(`/api/schedules?month=${FEV.month}&year=${FEV.year}`);
     const allEntries = schedRes.body.entries;
 
-    const week1Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK1);
-    const sixHourEntries = week1Work.filter((e) => e.duration_hours === 6);
+    const week2Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK2); // fix #96
+    const sixHourEntries = week2Work.filter((e) => e.duration_hours === 6);
 
     // Exatamente 1 turno de 6h na semana 42h
     expect(sixHourEntries).toHaveLength(1);
@@ -283,7 +283,7 @@ describe('Regra #90 — motorista DIURNO recebe turno extra de 6h em semana 42h'
     expect(['Manhã', 'Tarde']).toContain(sixHourEntries[0].shift_name);
   });
 
-  it('motorista DIURNO em semana 36h (FEV_WEEK3 e FEV_WEEK4) não tem turno extra de 6h', async () => {
+  it('motorista DIURNO em semana 36h (FEV_WEEK1 e FEV_WEEK4) // fix #96 não tem turno extra de 6h', async () => {
     const { emp } = await createDiurnoEmployee('Diurno 36h');
 
     await request(app).post('/api/schedules/generate').send(FEV);
@@ -291,10 +291,10 @@ describe('Regra #90 — motorista DIURNO recebe turno extra de 6h em semana 42h'
     const schedRes = await request(app).get(`/api/schedules?month=${FEV.month}&year=${FEV.year}`);
     const allEntries = schedRes.body.entries;
 
-    const week3Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK3);
+    const week1Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK1); // fix #96: cltWi=0 -> 36h
     const week4Work = workEntriesInWeek(allEntries, emp.id, FEV_WEEK4);
 
-    const sixHourIn36 = [...week3Work, ...week4Work].filter((e) => e.duration_hours === 6);
+    const sixHourIn36 = [...week1Work, ...week4Work].filter((e) => e.duration_hours === 6);
     expect(sixHourIn36).toHaveLength(0);
   });
 });

--- a/backend/src/tests/partialWeek.test.js
+++ b/backend/src/tests/partialWeek.test.js
@@ -1,0 +1,152 @@
+/**
+ * test(generator): semanas parciais no início/fim do mês — issue #96
+ *
+ * Desenvolvedor Pleno
+ *
+ * Criterios de aceite (issue #96):
+ *   - Semana parcial inicial (< 7 dias) NAO recebe meta CLT
+ *   - O indice CLT (wi) comeca em 0 a partir da PRIMEIRA semana completa (7 dias).
+ *   - Semanas completas subsequentes recebem o padrao CLT correto conforme a fase.
+ *   - Geracao nao trava nem gera erro mesmo em casos extremos (Fev 2025: Sem 1 = 1 dia).
+ *
+ * Calendario de referencia — Abril/2026 (comeca Quarta = parcial):
+ *   Sem 0 (parcial): [01-04/04] = 4 dias
+ *   Sem 1 (Dom 05): [05-11/04] = 7 dias  cltWi=0
+ *   Sem 2 (Dom 12): [12-18/04] = 7 dias  cltWi=1
+ *   Sem 3 (Dom 19): [19-25/04] = 7 dias  cltWi=2
+ *   Sem 4 (Dom 26): [26-30/04] = 5 dias  cltWi=3 (parcial final)
+ *
+ * Fase CLT — cycle_start=Fev/2025 em Abr/2026:
+ *   elapsed=(2026*12+4)-(2025*12+2)=14 -> phase=((14%3)+3)%3+1=3
+ *   getWeekTypeFromPhase(3, wi): 0->42h, 1->36h, 2->42h, 3->42h
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../app.js';
+import { freshDb } from './helpers.js';
+
+const ABR_2026 = { month: 4, year: 2026 };
+const FEV_2025 = { month: 2, year: 2025 };
+
+const ABR_WEEK1_FULL = ['2026-04-05','2026-04-06','2026-04-07','2026-04-08','2026-04-09','2026-04-10','2026-04-11'];
+const ABR_WEEK2_FULL = ['2026-04-12','2026-04-13','2026-04-14','2026-04-15','2026-04-16','2026-04-17','2026-04-18'];
+const ABR_WEEK3_FULL = ['2026-04-19','2026-04-20','2026-04-21','2026-04-22','2026-04-23','2026-04-24','2026-04-25'];
+
+function workEntriesIn(entries, empId, dates) {
+  return entries.filter(
+    (e) => e.employee_id === empId && dates.includes(e.date) && !e.is_day_off
+  );
+}
+
+function totalHoursOf(entries, empId) {
+  return entries
+    .filter((e) => e.employee_id === empId && !e.is_day_off)
+    .reduce((sum, e) => sum + (e.duration_hours || 0), 0);
+}
+
+function weeklyHoursOf(entries, empId, dates) {
+  return entries
+    .filter((e) => e.employee_id === empId && dates.includes(e.date) && !e.is_day_off)
+    .reduce((sum, e) => sum + (e.duration_hours || 0), 0);
+}
+
+async function createNoturnoEmployee(name, cycleStartMonth, cycleStartYear) {
+  const shiftsRes = await request(app).get('/api/shift-types');
+  const noturnoId = shiftsRes.body.find((s) => s.name === 'Noturno')?.id;
+  expect(noturnoId).toBeDefined();
+  const empRes = await request(app).post('/api/employees').send({
+    name,
+    setores: ['Transporte Ambulância'],
+    cycle_start_month: cycleStartMonth,
+    cycle_start_year: cycleStartYear,
+    restRules: { preferred_shift_id: noturnoId, notes: null },
+  });
+  expect(empRes.status).toBe(201);
+  return empRes.body;
+}
+
+async function createDiurnoEmployee(name, cycleStartMonth, cycleStartYear) {
+  const shiftsRes = await request(app).get('/api/shift-types');
+  const diurnoId = shiftsRes.body.find((s) => s.name === 'Diurno')?.id;
+  expect(diurnoId).toBeDefined();
+  const empRes = await request(app).post('/api/employees').send({
+    name,
+    setores: ['Transporte Ambulância'],
+    cycle_start_month: cycleStartMonth,
+    cycle_start_year: cycleStartYear,
+    restRules: { preferred_shift_id: diurnoId, notes: null },
+  });
+  expect(empRes.status).toBe(201);
+  return empRes.body;
+}
+
+beforeEach(() => freshDb());
+
+describe('Teste 1 — NOTURNO em Abril/2026 (semana parcial inicial de 4 dias)', () => {
+  it('semana completa cltWi=0 (05-11/Abr) recebe 42h NOTURNO (3x12h + 1x6h)', async () => {
+    const emp = await createNoturnoEmployee('Noturno Abr', 2, 2025);
+    const genRes = await request(app).post('/api/schedules/generate').send(ABR_2026);
+    expect(genRes.status).toBe(200);
+    const schedRes = await request(app).get('/api/schedules?month=4&year=2026');
+    expect(schedRes.status).toBe(200);
+    const entries = schedRes.body.entries;
+    const week1Hours = weeklyHoursOf(entries, emp.id, ABR_WEEK1_FULL);
+    const week2Hours = weeklyHoursOf(entries, emp.id, ABR_WEEK2_FULL);
+    const week3Hours = weeklyHoursOf(entries, emp.id, ABR_WEEK3_FULL);
+    expect(week1Hours).toBe(42);
+    expect(week2Hours).toBe(36);
+    expect(week3Hours).toBe(42);
+  });
+
+  it('total mensal >= 100h (sanity check)', async () => {
+    const emp = await createNoturnoEmployee('Noturno Abr Sanity', 2, 2025);
+    const genRes = await request(app).post('/api/schedules/generate').send(ABR_2026);
+    expect(genRes.status).toBe(200);
+    const schedRes = await request(app).get('/api/schedules?month=4&year=2026');
+    const totalHours = totalHoursOf(schedRes.body.entries, emp.id);
+    expect(totalHours).toBeGreaterThanOrEqual(100);
+  });
+
+  it('DIURNO em Abril/2026: cltWi=1 (12-18/Abr) recebe 36h sem turno 6h', async () => {
+    const emp = await createDiurnoEmployee('Diurno Abr', 2, 2025);
+    const genRes = await request(app).post('/api/schedules/generate').send(ABR_2026);
+    expect(genRes.status).toBe(200);
+    const schedRes = await request(app).get('/api/schedules?month=4&year=2026');
+    const entries = schedRes.body.entries;
+    const week2Hours = weeklyHoursOf(entries, emp.id, ABR_WEEK2_FULL);
+    expect(week2Hours).toBe(36);
+    const week2Entries = workEntriesIn(entries, emp.id, ABR_WEEK2_FULL);
+    const hasSixHour = week2Entries.some((e) => e.duration_hours === 6);
+    expect(hasSixHour).toBe(false);
+  });
+});
+
+describe('Teste 2 — Fevereiro/2025 (semana parcial extrema de 1 dia)', () => {
+  it('geração nao trava nem gera erro — status 200 para NOTURNO', async () => {
+    await createNoturnoEmployee('Noturno Fev', 2, 2025);
+    const genRes = await request(app).post('/api/schedules/generate').send(FEV_2025);
+    expect(genRes.status).toBe(200);
+    expect(genRes.body.success).toBe(true);
+  });
+
+  it('geração nao trava nem gera erro — status 200 para DIURNO', async () => {
+    await createDiurnoEmployee('Diurno Fev', 2, 2025);
+    const genRes = await request(app).post('/api/schedules/generate').send(FEV_2025);
+    expect(genRes.status).toBe(200);
+    expect(genRes.body.success).toBe(true);
+  });
+
+  it('NOTURNO Fev/2025: entradas cobrindo todos os 28 dias do mes', async () => {
+    const emp = await createNoturnoEmployee('Noturno Fev Full', 2, 2025);
+    await request(app).post('/api/schedules/generate').send(FEV_2025);
+    const schedRes = await request(app).get('/api/schedules?month=2&year=2025');
+    const empEntries = schedRes.body.entries.filter((e) => e.employee_id === emp.id);
+    expect(empEntries.length).toBe(28);
+    const dates = empEntries.map((e) => e.date);
+    for (let d = 1; d <= 28; d++) {
+      const dateStr = '2025-02-' + String(d).padStart(2, '0');
+      expect(dates).toContain(dateStr);
+    }
+  });
+});


### PR DESCRIPTION
## Resumo

- Detecta semana inicial parcial (< 7 dias) em `generateForEmployee` via `firstWeekIsPartial` e `cltWeekOffset`
- Semanas parciais nao recebem meta CLT - escalamos o que couber respeitando rest >= 24h e max 6 dias consecutivos
- Indice CLT (`wi`) agora conta a partir da primeira semana completa (`cltWi = wi - cltWeekOffset`)
- Afeta loops ADM e nao-ADM (NOTURNO/DIURNO) igualmente; `correctHours` tambem ajustado com `cltWeekOffsetCH`
- `weekClassifications` expoe `type: 'partial'` e `partial: true` para semanas parciais
- `noturno42h.test.js` atualizado: padrao CLT de Fev/2025 com cltWeekOffset=1 (FEV_WEEK1 agora e cltWi=0 -> 36h)

Closes #96

## Plano de teste

- [x] Todos os testes existentes passando (212/212 backend)
- [x] Novos testes: `partialWeek.test.js` - 6 testes (Abr/2026 parcial 4 dias; Fev/2025 parcial extremo 1 dia)
- [x] `noturno42h.test.js` 9/9 passando com semanas CLT corrigidas

## Evidencia - Output dos testes

```
 Test Files  17 passed (17)
       Tests 212 passed (212)
    Duration  4.11s
```

## Decisoes de implementacao relevantes para o Revisor

1. **Enforcement nao usa cltWeekOffset**: `enforceDiurnoCoverage`, `enforceNocturnalCoverage` e `enforceDailyCoverage` continuam com `bounds.weekIndex` raw (sem ajuste). Semanas parciais tem poucas horas naturalmente - impacto pratico minimo.
2. **Fallback '36h' para semanas parciais ADM**: max 3 turnos (conservador para poucos dias disponiveis).
3. **correctHours** usa `cltWeekOffsetCH` proprio - necessario pois e exportada e pode ser chamada com weeks arbitrarios.

Desenvolvedor Pleno