### PR TITLE
fix #100: semana 42h com Dom bloqueado → 36h uniformes para 100% dos motoristas

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -445,6 +445,10 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
           // Qual posição recebe o turno extra de 6h (Manhã ou Tarde)
           const extraPositionIndex = employee.id % activePositions.length;
 
+          // Fix #100: se qualquer posição for pulada por rest cross-week, as posições
+          // restantes devem receber 12h (não 6h), garantindo 36h uniformes.
+          let skippedAny = false;
+
           for (let pi = 0; pi < activePositions.length; pi++) {
             const date = available[activePositions[pi]];
 
@@ -452,20 +456,23 @@ function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwrit
             // Sáb DIURNO (semana N) termina 19:00; Dom DIURNO (semana N+1) começa 07:00 = 12h < 24h.
             // Se o descanso for insuficiente e não for emendado válido, pula esta posição (vira folga).
             if (lastShiftEnd) {
-              const shiftRef = (pi === extraPositionIndex) ? (manhaShift || tardeShift) : preferredShift;
+              const shiftRef = (!skippedAny && pi === extraPositionIndex) ? (manhaShift || tardeShift) : preferredShift;
               if (shiftRef) {
                 const dStart = computeShiftStart(date, shiftRef);
                 if (dStart) {
                   const restHours = (dStart - lastShiftEnd) / (1000 * 60 * 60);
                   if (restHours >= 0 && restHours < MIN_REST_HOURS) {
-                    if (!isValidEmendado(lastShiftName, shiftRef.name)) continue;
+                    if (!isValidEmendado(lastShiftName, shiftRef.name)) {
+                      skippedAny = true;
+                      continue;
+                    }
                   }
                 }
               }
             }
 
             activeDates.add(date);
-            if (pi === extraPositionIndex) {
+            if (!skippedAny && pi === extraPositionIndex) {
               // Turno extra de 6h
               const extraShift = manhaShift || tardeShift;
               if (extraShift) {


### PR DESCRIPTION
## Problema

Quando Dom (posição 0) era bloqueado por rest cross-week (fix #98B), `extraPositionIndex` ainda apontava para o índice original calculado com `employee.id % 4`.

Resultado: motoristas com `id%4=1,2,3` recebiam turno extra de 6h em Ter/Qui/Sáb → **30h em vez de 36h** (75% dos motoristas afetados).

## Root cause

```js
// linha 446 — calculado ANTES do loop, não considera posições puladas
const extraPositionIndex = employee.id % activePositions.length;
```

| id%4 | Extra em | Dom bloqueado → horas | Status |
|------|----------|----------------------|--------|
| 0 | Dom (pulado) | Ter+Qui+Sáb = 36h | ✅ OK |
| 1 | Ter | Dom(skip)+Ter(6h)+Qui(12h)+Sáb(12h) = 30h | ❌ bug |
| 2 | Qui | Dom(skip)+Ter(12h)+Qui(6h)+Sáb(12h) = 30h | ❌ bug |
| 3 | Sáb | Dom(skip)+Ter(12h)+Qui(12h)+Sáb(6h) = 30h | ❌ bug |

## Fix (cirúrgico — 1 flag, +10 linhas)

Flag `skippedAny`: se qualquer posição foi pulada por rest insuficiente, o turno extra de 6h é desativado — todas as posições restantes recebem 12h.

```js
let skippedAny = false;
// ao pular: skippedAny = true
// ao atribuir turno: if (!skippedAny && pi === extraPositionIndex)
```

Resultado com Dom bloqueado: Ter(12h)+Qui(12h)+Sáb(12h) = **36h para 100% dos motoristas**.

## Testes

212/212 passando (regressão completa).

```
Test Files  17 passed (17)
Tests       212 passed (212)
```

Closes #100