### PR TITLE
test(generator): cobertura fix #100 — DIURNO 42h Dom bloqueado (skippedAny)

### DIFF
--- a/backend/src/tests/diurno42hSkipExtra.test.js
+++ b/backend/src/tests/diurno42hSkipExtra.test.js
@@ -1,0 +1,211 @@
+/**
+ * test(generator): fix #100 — semana 42h com Dom bloqueado por rest cross-week
+ *
+ * Tester Senior
+ *
+ * Bug #100: quando Dom é bloqueado por rest cross-week (fix #98B), a flag
+ * `extraPositionIndex = employee.id % 4` ainda apontava para o índice original.
+ * Motoristas com id%4=1,2,3 recebiam turno extra de 6h em Ter/Qui/Sáb → 30h.
+ *
+ * Fix: flag `skippedAny` desativa o turno extra de 6h quando qualquer posição
+ * é pulada — todos os turnos restantes recebem 12h, garantindo 36h uniformes.
+ *
+ * Cenários:
+ *
+ * Teste 1 — Regressão: Dom disponível → 42h (sem regressão)
+ *   Jun/2025, cycle_start=Mai/2025 → fase 2 → semana 0 = 42h.
+ *   Jun começa num domingo → cltWeekOffset=0 → Dom Jun 1 é a posição 0.
+ *   lastShiftEnd=null no início do mês → Dom não sofre check de rest → disponível.
+ *   Esperado: weekHours===42, exatamente 1 turno com duration_hours===6.
+ *
+ * Teste 2 — Fix principal: 4 motoristas (id%4=0,1,2,3) com Dom bloqueado → 36h
+ *   Jan/2025, cycle_start=Jan/2025 → fase 1 → ['36h','42h','42h','36h'].
+ *   Semana 3 (Jan 19–25): cltWi=2 → 42h.
+ *   Semana 2 (Jan 12–18): último turno = Sáb Jan 18 19:00.
+ *   Dom Jan 19 07:00 = 12h rest < 24h → bloqueado para todos os motoristas.
+ *   Criar 4 motoristas (ids 1–4 → id%4 = 1,2,3,0 — todos os restos cobertos).
+ *   Esperado por motorista: weekHours===36, 0 turnos de 6h, Dom is_day_off===1.
+ *
+ * Teste 3 — Rest ≥ 24h: nenhum par consecutivo de turnos viola MIN_REST_HOURS
+ *   Usa a mesma geração de Jan/2025 do Teste 2.
+ *
+ * Teste 4 — Total mensal: monthTotal em [144, 192] com Dom bloqueado em Wi=2
+ *   Jan/2025, 1 motorista. Semanas 36h+42h+42h(Dom bloqueado)+36h → total plausível.
+ *
+ * Teste 5 — Edge case: sem turnos de 6h quando Dom bloqueado (assertion estrita)
+ *   Mesmo cenário do Teste 2: para cada motorista, extraShifts.length===0.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../app.js';
+import { freshDb } from './helpers.js';
+
+beforeEach(() => freshDb());
+
+// ── Constantes de cenário ────────────────────────────────────────────────────
+
+const JUN2025 = { month: 6, year: 2025 };
+const JAN2025 = { month: 1, year: 2025 };
+
+// Semana 0 de Jun/2025 (Dom Jun 1 → Sáb Jun 7) — para regressão
+const WEEK0_JUN = { start: '2025-06-01', end: '2025-06-07' };
+
+// Semana 3 de Jan/2025 (Dom Jan 19 → Sáb Jan 25) — Dom bloqueado (rest=12h)
+const WEEK3_JAN = { start: '2025-01-19', end: '2025-01-25' };
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function weekEntries(allEntries, empId, { start, end }) {
+  return allEntries.filter(
+    (e) => e.employee_id === empId && e.date >= start && e.date <= end
+  );
+}
+
+function weekHours(entries) {
+  return entries.reduce((sum, e) => (e.is_day_off ? sum : sum + (e.duration_hours || 0)), 0);
+}
+
+async function createDiurnoEmployee(name, cycleStartMonth, cycleStartYear) {
+  const res = await request(app)
+    .post('/api/employees')
+    .send({
+      name,
+      setores: ['Transporte Ambulância'],
+      cycle_start_month: cycleStartMonth,
+      cycle_start_year: cycleStartYear,
+    });
+  expect(res.status).toBe(201);
+  return res.body.id;
+}
+
+async function generateAndFetchEntries(monthYear) {
+  const genRes = await request(app).post('/api/schedules/generate').send(monthYear);
+  expect(genRes.status).toBe(200);
+  expect(genRes.body.success).toBe(true);
+
+  const schedRes = await request(app)
+    .get(`/api/schedules?month=${monthYear.month}&year=${monthYear.year}`);
+  expect(schedRes.status).toBe(200);
+  return schedRes.body.entries;
+}
+
+// ── Testes ───────────────────────────────────────────────────────────────────
+
+describe('fix #100 — DIURNO 42h semana com Dom bloqueado por rest cross-week', () => {
+
+  // ── Teste 1: Regressão — Dom disponível → 42h ──────────────────────────────
+  it('regressão: Dom disponível na semana 42h → 42h (4 turnos, exatamente 1 com 6h)', async () => {
+    // cycle_start=Mai/2025 → fase 2 → ['42h','42h','36h','42h']
+    // Jun/2025 começa num Dom → semana 0 é completa (cltWeekOffset=0)
+    // Dom Jun 1: lastShiftEnd=null → check de rest ignorado → Dom disponível
+    const empId = await createDiurnoEmployee('Motor Regressão', 5, 2025);
+
+    const allEntries = await generateAndFetchEntries(JUN2025);
+    const w0 = weekEntries(allEntries, empId, WEEK0_JUN);
+
+    const hours = weekHours(w0);
+    const workShifts = w0.filter((e) => !e.is_day_off);
+    const extraShifts = workShifts.filter((e) => e.duration_hours === 6);
+
+    expect(hours).toBe(42);
+    expect(workShifts.length).toBe(4);
+    expect(extraShifts.length).toBe(1);
+  });
+
+  // ── Teste 2: Fix principal — 4 motoristas com Dom bloqueado → todos 36h ───
+  it('fix: 4 motoristas (id%4=0,1,2,3) com Dom Jan 19 bloqueado por rest → weekHours===36 cada', async () => {
+    // cycle_start=Jan/2025 → fase 1 → ['36h','42h','42h','36h']
+    // Semana 2 (Jan 12–18): 42h, último turno = Sáb Jan 18 19:00
+    // Semana 3 (Jan 19–25): 42h, Dom Jan 19 07:00 → rest=12h < 24h → BLOQUEADO
+    // 4 motoristas: ids 1,2,3,4 → id%4 = 1,2,3,0 (todos os restos cobertos)
+    const ids = [];
+    for (let i = 0; i < 4; i++) {
+      ids.push(await createDiurnoEmployee(`Motor Fix100 ${i}`, 1, 2025));
+    }
+
+    const allEntries = await generateAndFetchEntries(JAN2025);
+
+    for (const empId of ids) {
+      const w3 = weekEntries(allEntries, empId, WEEK3_JAN);
+
+      // Horas da semana: deve ser exatamente 36h (3 × 12h)
+      const hours = weekHours(w3);
+      expect(hours, `empId=${empId} id%4=${empId % 4} weekHours`).toBe(36);
+
+      // Nenhum turno de 6h — o turno extra não deve ser atribuído com Dom bloqueado
+      const extraShifts = w3.filter((e) => !e.is_day_off && e.duration_hours === 6);
+      expect(extraShifts.length, `empId=${empId} id%4=${empId % 4} extraShifts`).toBe(0);
+
+      // Dom Jan 19 deve ser folga
+      const domEntry = w3.find((e) => e.date === '2025-01-19');
+      expect(domEntry, `empId=${empId} domEntry existe`).toBeDefined();
+      expect(domEntry.is_day_off, `empId=${empId} Dom is_day_off`).toBe(1);
+    }
+  });
+
+  // ── Teste 3: Rest ≥ 24h em todos os pares de turnos ───────────────────────
+  it('rest: nenhum par consecutivo de turnos viola MIN_REST_HOURS=24h em Jan/2025', async () => {
+    const empId = await createDiurnoEmployee('Motor Rest24h', 1, 2025);
+    const allEntries = await generateAndFetchEntries(JAN2025);
+
+    const workEntries = allEntries
+      .filter((e) => e.employee_id === empId && !e.is_day_off && e.start_time && e.duration_hours)
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    let lastEnd = null;
+    for (const entry of workEntries) {
+      const [h, m] = entry.start_time.split(':').map(Number);
+      const start = new Date(
+        `${entry.date}T${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:00`
+      );
+
+      if (lastEnd !== null) {
+        const restHours = (start - lastEnd) / (1000 * 60 * 60);
+        // rest pode ser 0 (emendado válido) ou ≥ 24h — nunca entre 0 e 24h
+        if (restHours > 0) {
+          expect(restHours, `rest entre ${lastEnd.toISOString()} e ${start.toISOString()}`).toBeGreaterThanOrEqual(24);
+        }
+      }
+
+      lastEnd = new Date(start.getTime() + entry.duration_hours * 60 * 60 * 1000);
+    }
+  });
+
+  // ── Teste 4: Total mensal em [144, 192] com Dom bloqueado ─────────────────
+  it('total mensal: Jan/2025 com Dom Jan 19 bloqueado → monthTotal em [144, 192]', async () => {
+    const empId = await createDiurnoEmployee('Motor TotalMensal', 1, 2025);
+    const allEntries = await generateAndFetchEntries(JAN2025);
+
+    const empEntries = allEntries.filter((e) => e.employee_id === empId);
+    const monthTotal = empEntries.reduce(
+      (sum, e) => (e.is_day_off ? sum : sum + (e.duration_hours || 0)),
+      0
+    );
+
+    expect(monthTotal).toBeGreaterThanOrEqual(144);
+    expect(monthTotal).toBeLessThanOrEqual(192);
+  });
+
+  // ── Teste 5: Assertion estrita — 0 turnos de 6h quando Dom bloqueado ──────
+  it('edge: nenhum dos 4 motoristas recebe turno de 6h na semana com Dom bloqueado', async () => {
+    const ids = [];
+    for (let i = 0; i < 4; i++) {
+      ids.push(await createDiurnoEmployee(`Motor Edge100 ${i}`, 1, 2025));
+    }
+
+    const allEntries = await generateAndFetchEntries(JAN2025);
+
+    for (const empId of ids) {
+      const w3 = weekEntries(allEntries, empId, WEEK3_JAN);
+
+      // Assertion estrita: nenhum turno de 6h — não usar toBeGreaterThanOrEqual(0)
+      const extraShifts = w3.filter((e) => !e.is_day_off && e.duration_hours === 6);
+      expect(extraShifts.length).toBe(0);
+
+      // Dom Jan 19 is_day_off===1 — não usar toBeTruthy()
+      const domEntry = w3.find((e) => e.date === '2025-01-19');
+      expect(domEntry?.is_day_off).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
## Contexto

Testes específicos para o fix #100 (PR #101): quando Dom é bloqueado por rest cross-week em semana 42h, todos os motoristas devem receber 36h uniformes.

## Cenários cobertos

| # | Cenário | Assertion |
|---|---------|-----------|
| 1 | Regressão: Dom disponível → 42h | `weekHours===42`, `extraShifts.length===1` |
| 2 | Fix: 4 motoristas (id%4=0,1,2,3) com Dom bloqueado → 36h | `weekHours===36` para todos |
| 3 | Rest ≥ 24h em todos os pares de turnos (Jan/2025) | `restHours >= 24` |
| 4 | Total mensal com Dom bloqueado | `monthTotal in [144, 192]` |
| 5 | Edge: 0 turnos de 6h, Dom `is_day_off===1` | assertions estritas `toBe(0)`, `toBe(1)` |

## Resultado

```
Test Files  18 passed (18)
Tests       217 passed (217)
```

Relacionado: closes #100 (testes), PR de fix: #101