### PR TITLE
fix(enforcement): Passo 4 — ignorar withinWeeklyLimit como ultimo recurso (#107)

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -1278,6 +1278,9 @@ function enforceNocturnalCoverage(db, employees, employeeSectorsMap, dates, notu
  *   Emite sem_motorista_forcado (1º) ou segundo_motorista_forcado (2º+).
  * Passo 3 (emergência): força até candidatos seg_sex em Sáb/Dom quando não há outro.
  *   Ainda respeita limite CLT semanal. Emite warning sem_motorista_forcado_seg_sex para rastreabilidade.
+ * Passo 4 (último recurso): ignora limite CLT semanal — usado quando todos workers atingiram o limite
+ *   CLT semanal antes do fim da semana. Seleciona candidato com menor carga mensal para minimizar
+ *   sobrecarga. Emite clt_weekly_overflow para rastreabilidade.
  * Emite sem_motorista (filled=0) ou cobertura_minima_insuficiente (filled>0 mas <MIN)
  *   quando não há candidatos disponíveis.
  */
@@ -1487,6 +1490,32 @@ export function enforceDailyCoverage(db, employees, employeeSectorsMap, shiftTyp
         forced = true;
         break;
       }
+      // Passo 4 (último recurso): ignora limite CLT semanal — todos os passos anteriores falharam.
+      // Ocorre quando todos os workers atingiram o limite CLT semanal antes do fim da semana.
+      // Seleciona o candidato com menor carga mensal para minimizar sobrecarga.
+      if (!forced) {
+        const byHours = [...candidates].sort(
+          (a, b) =>
+            getEmployeeHours(db, a.emp.id, startDate, endDate) -
+            getEmployeeHours(db, b.emp.id, startDate, endDate)
+        );
+        for (const { folgaId, emp } of byHours) {
+          if (getEmployeeHours(db, emp.id, startDate, endDate) >= COVERAGE_HOURS_CAP) continue;
+          const shift = getShiftForEmp(emp);
+          db.prepare('UPDATE schedule_entries SET is_day_off = 0, shift_type_id = ? WHERE id = ?')
+            .run(shift.id, folgaId);
+          warnings.push({
+            type: 'clt_weekly_overflow',
+            date,
+            employee: emp.name,
+            message: `${date}: cobertura forçada para ${emp.name} — limite CLT semanal excedido (último recurso)`,
+          });
+          filled++;
+          forced = true;
+          break;
+        }
+      }
+
       if (!forced) {
         if (filled === 0) {
           warnings.push({ type: 'sem_motorista', date, message: `${date}: nenhum motorista escalado` });

--- a/backend/src/tests/apr10coverage.test.js
+++ b/backend/src/tests/apr10coverage.test.js
@@ -1,0 +1,105 @@
+/**
+ * test: regressão issue #107 — Apr10 cobertura zero (withinWeeklyLimit overflow)
+ *
+ * Desenvolvedor Pleno
+ *
+ * Verifica que o Passo 4 do enforceDailyCoverage resolve o gap de cobertura
+ * quando todos os workers atingem o limite CLT semanal antes de sexta.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../app.js';
+import { freshDb } from './helpers.js';
+
+beforeEach(() => freshDb());
+
+const APR2026 = { month: 4, year: 2026 };
+const SHIFT_DIURNO_ID = 1;
+
+async function createWorker(name, csm, csy) {
+  const res = await request(app).post('/api/employees').send({
+    name,
+    setores: ['Transporte Ambulância'],
+    cycle_start_month: csm,
+    cycle_start_year: csy,
+    work_schedule: 'dom_sab',
+    restRules: { preferred_shift_id: SHIFT_DIURNO_ID },
+  });
+  expect(res.status, `createWorker ${name}`).toBe(201);
+  return res.body.id;
+}
+
+async function generateApril() {
+  const res = await request(app)
+    .post('/api/schedules/generate')
+    .send({ ...APR2026, overwriteLocked: true });
+  expect(res.status, 'generate').toBe(200);
+  return res.body;
+}
+
+describe('Issue #107 — Passo 4: Apr10 cobertura com clt_weekly_overflow', () => {
+  it('Apr10 (Sex) deve ter cobertura >= 1 apos Passo 4', async () => {
+    await createWorker('Amb 1', 1, 2026);
+    await createWorker('Amb 2', 2, 2026);
+    await createWorker('Amb 3', 3, 2026);
+    await createWorker('Amb 4', 1, 2026);
+
+    await generateApril();
+
+    const entries = await request(app)
+      .get('/api/schedules?month=4&year=2026')
+      .then((r) => r.body.entries);
+
+    const apr10Workers = entries.filter((e) => e.date === '2026-04-10' && !e.is_day_off);
+    expect(apr10Workers.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('deve emitir warning clt_weekly_overflow quando todos workers tem semana 36h (Passo 4 acionado)', async () => {
+    // Todos com cycle_start=1/2026 => phase=1 => semana Apr5-Apr11 cltWi=0 => '36h' (limite 36h/3 turnos)
+    // Apos 3 turnos (Dom+Qua+Sex ou Dom+Ter+Qui), limite atingido => Passo 4 dispara em algum dia da semana
+    await createWorker('Amb 1', 1, 2026);
+    await createWorker('Amb 2', 1, 2026);
+    await createWorker('Amb 3', 1, 2026);
+    await createWorker('Amb 4', 1, 2026);
+
+    const gen = await generateApril();
+    const warnings = gen.warnings || [];
+
+    // Deve existir pelo menos 1 warning clt_weekly_overflow em alguma data de Abril
+    const overflowWarnings = warnings.filter((w) => w.type === 'clt_weekly_overflow');
+    expect(overflowWarnings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('sem_motorista NAO deve aparecer para Apr10', async () => {
+    await createWorker('Amb 1', 1, 2026);
+    await createWorker('Amb 2', 2, 2026);
+    await createWorker('Amb 3', 3, 2026);
+    await createWorker('Amb 4', 1, 2026);
+
+    const gen = await generateApril();
+    const warnings = gen.warnings || [];
+
+    const semMotoristaApr10 = warnings.filter(
+      (w) => w.type === 'sem_motorista' && w.date === '2026-04-10'
+    );
+    expect(semMotoristaApr10.length).toBe(0);
+  });
+
+  it('total de horas por worker permanece <= 200h (Passo 4 nao causa sobrecarga extrema)', async () => {
+    await createWorker('Amb 1', 1, 2026);
+    await createWorker('Amb 2', 2, 2026);
+    await createWorker('Amb 3', 3, 2026);
+    await createWorker('Amb 4', 1, 2026);
+
+    await generateApril();
+
+    const totals = await request(app)
+      .get('/api/schedules?month=4&year=2026')
+      .then((r) => r.body.totals || []);
+
+    for (const t of totals) {
+      expect(t.total_hours, `worker ${t.employee_id} horas`).toBeLessThanOrEqual(200);
+    }
+  });
+});

--- a/backend/src/tests/aprilSchedule2026.test.js
+++ b/backend/src/tests/aprilSchedule2026.test.js
@@ -72,9 +72,8 @@ const APR_DATES = Array.from({ length: APR_DAYS }, (_, i) => {
 // não há Noturno disponível para Apr1-Apr4 sem violar rest CLT.
 const PARTIAL_WEEK_DATES = new Set(['2026-04-01', '2026-04-02', '2026-04-03', '2026-04-04']);
 
-// Apr10 excluída de R2: workers atingem limite CLT semanal (semana Apr5-Apr11) antes de Apr10.
-// TODO: abrir issue para corrigir distribuição semanal e garantir cobertura em todos os dias.
-const R2_SKIP_DATES = new Set(['2026-04-10']);
+// Fix #107: Apr10 agora coberta pelo Passo 4 (clt_weekly_overflow) — sem exclusão necessária.
+const R2_SKIP_DATES = new Set();
 
 // ── Helpers de criação via API ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problema

Na semana Apr5-Apr11, todos os workers `dom_sab` atingem o limite CLT semanal (36h ou 42h) antes de sexta-feira.
Os Passos 1, 2 e 3 do `enforceDailyCoverage` verificam `withinWeeklyLimit` — quando todos estão no limite, todos os passos falham, resultando em cobertura zero sem warning.

## Solucao

Adicionado **Passo 4** ao `enforceDailyCoverage`: quando Passos 1-3 falham, ignora `withinWeeklyLimit` como ultimo recurso, selecionando o worker com menor carga mensal e emitindo warning `clt_weekly_overflow`.

Restricao mantida: `COVERAGE_HOURS_CAP` (160h mensais) ainda e verificado, evitando sobrecarga extrema.

## Evidencia de funcionamento

**Antes do fix**: Apr10 -> 0 workers, warning `cobertura_minima_insuficiente`

**Apos o fix**: Apr10 -> worker atribuido com warning `clt_weekly_overflow`

**230/230 testes passando** (4 novos testes em `apr10coverage.test.js`, Apr10 removido do `R2_SKIP_DATES`)

## Plano de teste

1. Cobertura >= 1 em Apr10 com 4 workers diurno
2. `clt_weekly_overflow` warning gerado quando todos workers tem semana 36h
3. Sem `sem_motorista` para Apr10
4. Horas por worker <= 200h (sem sobrecarga extrema)
5. Apr10 incluida na validacao de cobertura >= 2 com 7 workers (aprilSchedule2026)