### PR TITLE
feature(crew): validacao de crew minimo pre-geracao com aviso na UI (#110)

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -136,6 +136,50 @@ function getWeekTypeFromPhase(phase, weekIndex) {
   return patterns[phase][Math.min(weekIndex, 3)];
 }
 
+// Configuração mínima de crew recomendada (decisão PO — issue #108)
+const MIN_HEMO_WORKERS   = 4; // para garantir R5: ≥2 Hemo Diurno em todos os dias úteis
+const MIN_AMB_NOTURNO    = 4; // para garantir R3: ≥2 Noturno Amb em Qui/Sáb
+
+/**
+ * Verifica se o elenco ativo atende à configuração mínima recomendada.
+ * Retorna array de crew_warnings (vazio se tudo OK).
+ */
+function checkCrewMinimum(db, shiftTypes) {
+  const crew_warnings = [];
+  const noturnoShift = shiftTypes.find((s) => s.name === SHIFT_NOTURNO_NAME);
+
+  const hemoCount = db.prepare(
+    `SELECT COUNT(DISTINCT e.id) as c FROM employees e
+     JOIN employee_sectors es ON es.employee_id = e.id
+     WHERE e.active = 1 AND es.setor = ?`
+  ).get(SETOR_HEMO).c;
+
+  if (hemoCount < MIN_HEMO_WORKERS) {
+    crew_warnings.push({
+      type: 'crew_hemo_insuficiente',
+      message: `Cobertura Diurno Hemodiálise pode ser insuficiente: ${hemoCount}/${MIN_HEMO_WORKERS} workers ativos (mínimo recomendado para garantir ≥2/dia útil)`,
+    });
+  }
+
+  const ambNoturnoCount = noturnoShift
+    ? db.prepare(
+        `SELECT COUNT(DISTINCT e.id) as c FROM employees e
+         JOIN employee_sectors es ON es.employee_id = e.id
+         LEFT JOIN employee_rest_rules r ON r.employee_id = e.id
+         WHERE e.active = 1 AND es.setor = ? AND r.preferred_shift_id = ?`
+      ).get(SETOR_AMBUL, noturnoShift.id).c
+    : 0;
+
+  if (ambNoturnoCount < MIN_AMB_NOTURNO) {
+    crew_warnings.push({
+      type: 'crew_amb_noturno_insuficiente',
+      message: `Cobertura Noturno Ambulância pode ser insuficiente: ${ambNoturnoCount}/${MIN_AMB_NOTURNO} workers com turno Noturno preferido (mínimo recomendado para garantir ≥2 em Qui/Sáb)`,
+    });
+  }
+
+  return crew_warnings;
+}
+
 /**
  * Main schedule generation algorithm (greedy + correction step)
  * Target: 160h/month per employee
@@ -187,6 +231,7 @@ export async function generateSchedule({ month, year, overwriteLocked = false })
     }
   }
 
+  const crew_warnings = checkCrewMinimum(db, shiftTypes);
   const warnings = [];
   const results = [];
 
@@ -214,7 +259,7 @@ export async function generateSchedule({ month, year, overwriteLocked = false })
     'INSERT INTO schedule_generations (month, year, params_json) VALUES (?, ?, ?)'
   ).run(month, year, JSON.stringify({ overwriteLocked, employeeCount: employees.length, warnings, results }));
 
-  return { results, warnings };
+  return { results, warnings, crew_warnings };
 }
 
 function generateForEmployee(db, employee, shiftTypes, shiftMap, dates, overwriteLocked, warnings, allVacationDates, genMonth, genYear) {

--- a/backend/src/tests/crewMinimum.test.js
+++ b/backend/src/tests/crewMinimum.test.js
@@ -1,0 +1,105 @@
+/**
+ * test: crew minimum validation — issue #110
+ *
+ * Desenvolvedor Pleno
+ *
+ * Verifica que generateSchedule retorna crew_warnings quando o elenco ativo
+ * está abaixo da configuração mínima recomendada (4 Hemo + 4 Amb Noturno).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../app.js';
+import { freshDb } from './helpers.js';
+
+beforeEach(() => freshDb());
+
+const SHIFT_NOTURNO_ID = 2;
+const SHIFT_DIURNO_ID  = 1;
+
+async function createWorker(name, setor, preferredShiftId = null) {
+  const body = {
+    name,
+    setores: [setor],
+    cycle_start_month: 1,
+    cycle_start_year: 2026,
+    work_schedule: 'dom_sab',
+  };
+  if (preferredShiftId !== null) body.restRules = { preferred_shift_id: preferredShiftId };
+  const res = await request(app).post('/api/employees').send(body);
+  expect(res.status, `createWorker ${name}`).toBe(201);
+  return res.body.id;
+}
+
+async function generate() {
+  const res = await request(app)
+    .post('/api/schedules/generate')
+    .send({ month: 4, year: 2026, overwriteLocked: true });
+  expect(res.status, 'generate').toBe(200);
+  return res.body;
+}
+
+describe('crew_warnings — configuração mínima de crew', () => {
+  it('retorna crew_warnings vazio quando elenco atende ao mínimo (4 Hemo + 4 Amb Noturno)', async () => {
+    for (let i = 1; i <= 4; i++) {
+      await createWorker(`Hemo ${i}`, 'Transporte Hemodiálise', SHIFT_DIURNO_ID);
+    }
+    for (let i = 1; i <= 4; i++) {
+      await createWorker(`Amb ${i}`, 'Transporte Ambulância', SHIFT_NOTURNO_ID);
+    }
+
+    const result = await generate();
+    expect(result.crew_warnings).toBeDefined();
+    expect(result.crew_warnings).toHaveLength(0);
+  });
+
+  it('emite crew_hemo_insuficiente quando há menos de 4 workers Hemo', async () => {
+    await createWorker('Hemo 1', 'Transporte Hemodiálise', SHIFT_DIURNO_ID);
+    await createWorker('Hemo 2', 'Transporte Hemodiálise', SHIFT_DIURNO_ID);
+    for (let i = 1; i <= 4; i++) {
+      await createWorker(`Amb ${i}`, 'Transporte Ambulância', SHIFT_NOTURNO_ID);
+    }
+
+    const result = await generate();
+    const hemoWarn = result.crew_warnings.find(w => w.type === 'crew_hemo_insuficiente');
+    expect(hemoWarn).toBeDefined();
+    expect(hemoWarn.message).toContain('2/4');
+  });
+
+  it('emite crew_amb_noturno_insuficiente quando há menos de 4 Amb com turno Noturno', async () => {
+    for (let i = 1; i <= 4; i++) {
+      await createWorker(`Hemo ${i}`, 'Transporte Hemodiálise', SHIFT_DIURNO_ID);
+    }
+    await createWorker('Amb 1', 'Transporte Ambulância', SHIFT_NOTURNO_ID);
+    await createWorker('Amb 2', 'Transporte Ambulância', SHIFT_NOTURNO_ID);
+    // Amb 3 e 4 sem preferred shift (não conta para o mínimo noturno)
+    await createWorker('Amb 3', 'Transporte Ambulância');
+    await createWorker('Amb 4', 'Transporte Ambulância');
+
+    const result = await generate();
+    const ambWarn = result.crew_warnings.find(w => w.type === 'crew_amb_noturno_insuficiente');
+    expect(ambWarn).toBeDefined();
+    expect(ambWarn.message).toContain('2/4');
+  });
+
+  it('emite ambos os warnings quando elenco está completamente abaixo do mínimo', async () => {
+    await createWorker('Hemo 1', 'Transporte Hemodiálise', SHIFT_DIURNO_ID);
+    await createWorker('Amb 1', 'Transporte Ambulância', SHIFT_NOTURNO_ID);
+
+    const result = await generate();
+    expect(result.crew_warnings).toHaveLength(2);
+    const types = result.crew_warnings.map(w => w.type);
+    expect(types).toContain('crew_hemo_insuficiente');
+    expect(types).toContain('crew_amb_noturno_insuficiente');
+  });
+
+  it('crew_warnings nao bloqueia a geracao — success=true mesmo com warnings', async () => {
+    // Elenco mínimo (1 de cada)
+    await createWorker('Hemo 1', 'Transporte Hemodiálise', SHIFT_DIURNO_ID);
+    await createWorker('Amb 1', 'Transporte Ambulância', SHIFT_NOTURNO_ID);
+
+    const result = await generate();
+    expect(result.success).toBe(true);
+    expect(result.crew_warnings.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/layout/Toast.jsx
+++ b/frontend/src/components/layout/Toast.jsx
@@ -1,9 +1,10 @@
-import { X, CheckCircle, AlertCircle, Info } from 'lucide-react';
+import { X, CheckCircle, AlertCircle, AlertTriangle, Info } from 'lucide-react';
 import useStore from '../../store/useStore.js';
 
 const icons = {
   success: <CheckCircle size={18} className="text-green-500" />,
   error: <AlertCircle size={18} className="text-red-500" />,
+  warning: <AlertTriangle size={18} className="text-amber-500" />,
   info: <Info size={18} className="text-blue-500" />,
 };
 

--- a/frontend/src/pages/SchedulePage.jsx
+++ b/frontend/src/pages/SchedulePage.jsx
@@ -72,6 +72,9 @@ export default function SchedulePage() {
         title: 'Escala gerada!',
         message: `${result.results?.length || 0} funcionário(s) escalado(s)`,
       });
+      for (const cw of result.crew_warnings || []) {
+        addToast({ type: 'warning', title: 'Configuração de equipe', message: cw.message, duration: 8000 });
+      }
     } catch (err) {
       addToast({ type: 'error', title: 'Erro ao gerar escala', message: err.message });
     }


### PR DESCRIPTION
## Feature

Implementa validacao de crew minimo recomendado (decisao PO — issue #108) antes de retornar o resultado da geracao.

## Mudancas

**Backend (`scheduleGenerator.js`)**
- `checkCrewMinimum(db, shiftTypes)`: verifica se elenco ativo tem >= 4 Hemo e >= 4 Amb com `preferred_shift=Noturno`
- `generateSchedule` retorna `crew_warnings[]` (novo campo, nao-vazio quando sub-minimo)
- Geracao NAO e bloqueada — apenas informativo

**Frontend (`Toast.jsx`)**
- Novo tipo `warning` com icone `AlertTriangle` amber

**Frontend (`SchedulePage.jsx`)**
- `handleGenerate` exibe cada `crew_warning` como toast `warning` (duracao 8s)

## Evidencia de funcionamento

**235/235 testes backend** + **144/144 testes frontend** (379 total)

5 novos testes em `crewMinimum.test.js`:
1. crew_warnings vazio com elenco completo (4 Hemo + 4 Amb Noturno)
2. `crew_hemo_insuficiente` com 2 Hemo
3. `crew_amb_noturno_insuficiente` com 2 Amb Noturno (outros sem preferencia nao contam)
4. Ambos os warnings com elenco minimo
5. Geracao continua com success=true mesmo com crew_warnings