### PR TITLE
feat(#115): crew_warning para cobertura diária geral insuficiente (dom_sab < 4)

### DIFF
--- a/backend/src/services/scheduleGenerator.js
+++ b/backend/src/services/scheduleGenerator.js
@@ -171,6 +171,7 @@ function getWeekTypeFromPhase(phase, weekIndex) {
 // Configuração mínima de crew recomendada (decisão PO — issue #108)
 const MIN_HEMO_WORKERS   = 4; // para garantir R5: ≥2 Hemo Diurno em todos os dias úteis
 const MIN_AMB_NOTURNO    = 4; // para garantir R3: ≥2 Noturno Amb em Qui/Sáb
+const MIN_DOM_SAB_WORKERS = 4; // para garantir MIN_DAILY_COVERAGE/dia incl. fins de semana (issue #115)
 
 /**
  * Verifica se o elenco ativo atende à configuração mínima recomendada.
@@ -206,6 +207,17 @@ function checkCrewMinimum(db, shiftTypes) {
     crew_warnings.push({
       type: 'crew_amb_noturno_insuficiente',
       message: `Cobertura Noturno Ambulância pode ser insuficiente: ${ambNoturnoCount}/${MIN_AMB_NOTURNO} workers com turno Noturno preferido (mínimo recomendado para garantir ≥2 em Qui/Sáb)`,
+    });
+  }
+
+  const domSabCount = db.prepare(
+    `SELECT COUNT(*) as c FROM employees WHERE active = 1 AND work_schedule != 'seg_sex'`
+  ).get().c;
+
+  if (domSabCount < MIN_DOM_SAB_WORKERS) {
+    crew_warnings.push({
+      type: 'crew_dom_sab_insuficiente',
+      message: `Cobertura diária geral pode ser insuficiente: ${domSabCount}/${MIN_DOM_SAB_WORKERS} workers dom_sab ativos (mínimo recomendado para garantir ≥${MIN_DAILY_COVERAGE}/dia incluindo fins de semana)`,
     });
   }
 

--- a/backend/src/tests/crewMinimum.test.js
+++ b/backend/src/tests/crewMinimum.test.js
@@ -82,15 +82,15 @@ describe('crew_warnings — configuração mínima de crew', () => {
     expect(ambWarn.message).toContain('2/4');
   });
 
-  it('emite ambos os warnings quando elenco está completamente abaixo do mínimo', async () => {
+  it('emite todos os warnings quando elenco está completamente abaixo do mínimo', async () => {
     await createWorker('Hemo 1', 'Transporte Hemodiálise', SHIFT_DIURNO_ID);
     await createWorker('Amb 1', 'Transporte Ambulância', SHIFT_NOTURNO_ID);
 
     const result = await generate();
-    expect(result.crew_warnings).toHaveLength(2);
     const types = result.crew_warnings.map(w => w.type);
     expect(types).toContain('crew_hemo_insuficiente');
     expect(types).toContain('crew_amb_noturno_insuficiente');
+    expect(types).toContain('crew_dom_sab_insuficiente');
   });
 
   it('crew_warnings nao bloqueia a geracao — success=true mesmo com warnings', async () => {
@@ -101,5 +101,66 @@ describe('crew_warnings — configuração mínima de crew', () => {
     const result = await generate();
     expect(result.success).toBe(true);
     expect(result.crew_warnings.length).toBeGreaterThan(0);
+  });
+});
+
+describe('crew_warnings — cobertura diária geral (dom_sab)', () => {
+  it('nao emite crew_dom_sab_insuficiente quando há 4 ou mais workers dom_sab', async () => {
+    for (let i = 1; i <= 4; i++) {
+      await createWorker(`Hemo ${i}`, 'Transporte Hemodiálise', SHIFT_DIURNO_ID);
+    }
+
+    const result = await generate();
+    const types = result.crew_warnings.map(w => w.type);
+    expect(types).not.toContain('crew_dom_sab_insuficiente');
+  });
+
+  it('emite crew_dom_sab_insuficiente quando há menos de 4 workers dom_sab', async () => {
+    await createWorker('Hemo 1', 'Transporte Hemodiálise', SHIFT_DIURNO_ID);
+    await createWorker('Hemo 2', 'Transporte Hemodiálise', SHIFT_DIURNO_ID);
+
+    const result = await generate();
+    const warn = result.crew_warnings.find(w => w.type === 'crew_dom_sab_insuficiente');
+    expect(warn).toBeDefined();
+    expect(warn.message).toContain('2/4');
+  });
+
+  it('workers seg_sex nao contam para o minimo dom_sab', async () => {
+    // 3 dom_sab + 2 seg_sex = total 5 ativos, mas dom_sab=3 < 4
+    for (let i = 1; i <= 3; i++) {
+      await createWorker(`Hemo ${i}`, 'Transporte Hemodiálise', SHIFT_DIURNO_ID);
+    }
+    const body = {
+      name: 'Adm 1',
+      setores: ['Transporte Administrativo'],
+      cycle_start_month: 1,
+      cycle_start_year: 2026,
+      work_schedule: 'seg_sex',
+    };
+    await request(app).post('/api/employees').send(body).expect(201);
+    await request(app).post('/api/employees').send({ ...body, name: 'Adm 2' }).expect(201);
+
+    const result = await generate();
+    const warn = result.crew_warnings.find(w => w.type === 'crew_dom_sab_insuficiente');
+    expect(warn).toBeDefined();
+    expect(warn.message).toContain('3/4');
+  });
+
+  it('nao emite crew_dom_sab_insuficiente com exatamente 4 workers dom_sab e alguns seg_sex', async () => {
+    for (let i = 1; i <= 4; i++) {
+      await createWorker(`Hemo ${i}`, 'Transporte Hemodiálise', SHIFT_DIURNO_ID);
+    }
+    const body = {
+      name: 'Adm 1',
+      setores: ['Transporte Administrativo'],
+      cycle_start_month: 1,
+      cycle_start_year: 2026,
+      work_schedule: 'seg_sex',
+    };
+    await request(app).post('/api/employees').send(body).expect(201);
+
+    const result = await generate();
+    const types = result.crew_warnings.map(w => w.type);
+    expect(types).not.toContain('crew_dom_sab_insuficiente');
   });
 });


### PR DESCRIPTION
## Contexto

Fecha issue #115.

`checkCrewMinimum` já validava Hemo Diurno e Amb Noturno, mas não alertava quando o total de workers `dom_sab` é insuficiente para garantir `MIN_DAILY_COVERAGE=2` em todos os dias, incluindo fins de semana.

Workers `seg_sex` (administrativos) não trabalham Sáb/Dom — por isso não contam para a cobertura de fim de semana.

Com descanso de 24h entre turnos de 12h, o mínimo para garantir ≥2 por dia é **4 workers dom_sab** (2 pares alternados).

## Mudanças

- `scheduleGenerator.js`: nova constante `MIN_DOM_SAB_WORKERS = 4` + check em `checkCrewMinimum`
- `crewMinimum.test.js`: 4 novos testes cobrindo elenco suficiente, insuficiente, mix com seg_sex

## Evidência

```
Test Files  21 passed (21)
      Tests 245 passed (245)
```

245/245 — todos passando (+4 novos).