### PR TITLE
test: validação de regras de negócio para todos os meses de 2026

### DIFF
--- a/backend/src/tests/allMonths2026.test.js
+++ b/backend/src/tests/allMonths2026.test.js
@@ -12,9 +12,9 @@
  *   - Geração bem-sucedida: success=true, sem warnings críticos (sem_motorista),
  *     sem crew_warnings (elenco mínimo atendido)
  *   - Regra 19/42: cobertura diária ≥ MIN_DAILY_COVERAGE (2) em todos os dias
- *   - Regra 4: descanso ≥ 12h entre turnos consecutivos por motorista
- *     (threshold ≥12h para acomodar pares emendados intra-dia; o gerador
- *     garante os 24h pós-bloco emendado)
+ *   - Regra 4: descanso ≥24h entre turnos consecutivos por motorista,
+ *     exceto pares emendados (Noturno→Manhã, Manhã→Tarde, Tarde→Noturno)
+ *     detectados pelo nome do turno + encaixe imediato (restMs ≤ 0)
  *   - Regra #30: máx 6 dias de trabalho consecutivos por motorista
  *   - Regra 12: workers seg_sex não trabalham aos Sábados ou Domingos
  *   - Durações válidas: apenas 6h, 10h ou 12h por turno trabalhado


### PR DESCRIPTION
## Contexto

Cobertura de QA para os 12 meses de 2026. Valida que o algoritmo de geração respeita as regras de negócio fundamentais em todos os períodos do ano, incluindo meses com 4 semanas (28 dias) e meses com 5 semanas (35 dias).

## Suítes

**Suite 1 — estrutura do período (12 testes):**
- Período inicia sempre no 1º domingo do mês (issue #112)
- Período termina sempre no sábado anterior ao 1º domingo do mês seguinte
- 4 semanas: Jan, Fev, Abr, Jun, Jul, Set, Out, Dez
- 5 semanas: Mar, Mai, Ago, Nov

**Suite 2 — regras de negócio por mês (72 testes, 6 × 12):**
- Geração bem-sucedida + sem `sem_motorista` + sem `crew_warnings`
- **Regra 19/42**: cobertura diária ≥2 em todos os dias
- **Regra 4**: descanso ≥24h entre turnos consecutivos, com detecção de pares emendados (`Noturno→Manhã`, `Manhã→Tarde`, `Tarde→Noturno`) que têm encaixe imediato por design
- **Regra #30**: máx 6 dias de trabalho consecutivos
- **Regra 12**: workers `seg_sex` não trabalham Sáb/Dom
- Durações válidas: apenas 6h, 10h ou 12h

## Evidência

```
Test Files  22 passed (22)
      Tests 329 passed (329)
```

329/329 — todos passando (+84 novos).