### PR TITLE
test: validar horas semanais CLT por fase do ciclo (#120)

### DIFF
--- a/backend/src/tests/cltWeekHours.test.js
+++ b/backend/src/tests/cltWeekHours.test.js
@@ -216,7 +216,7 @@ describe('Fase 2 — padrão [42h,42h,36h,42h]', () => {
   it('Ago/2025 (cycle_start=Jul/2025): semana cltWi=0 (Ago 3–9) → 42h com 1 turno de 6h', async () => {
     // Ago 1 = Sex → cltWeekOffset=1 → primeira semana completa = Ago 3–9 (cltWi=0)
     // Fase 2, cltWi=0 → '42h'
-    const empId = await createDiurnoWorker('DIURNO F2b 42h-w1', 7, 2025);
+    const empId = await createDiurnoWorker('DIURNO F2b 42h-cltWi=0', 7, 2025);
     const entries = await generateAndGetEntries(8, 2025);
 
     const week = entriesInRange(entries, empId, '2025-08-03', '2025-08-09');
@@ -233,7 +233,7 @@ describe('Fase 2 — padrão [42h,42h,36h,42h]', () => {
   it('Ago/2025 (cycle_start=Jul/2025): semana cltWi=2 (Ago 17–23) → 36h exatamente 3×12h', async () => {
     // Fase 2, cltWi=2 → '36h'
     // (semana cltWi=1 ignorada: Dom Ago 10 bloqueado por rest cross-week do Sáb Ago 9)
-    const empId = await createDiurnoWorker('DIURNO F2b 36h-w3', 7, 2025);
+    const empId = await createDiurnoWorker('DIURNO F2b 36h-cltWi=2', 7, 2025);
     const entries = await generateAndGetEntries(8, 2025);
 
     const week = entriesInRange(entries, empId, '2025-08-17', '2025-08-23');
@@ -353,7 +353,7 @@ describe('Lição bug #119 — preferred_shift_id Diurno explícito', () => {
     // Verificar via GET que o preferred_shift_id foi salvo corretamente
     const getRes = await request(app).get(`/api/employees/${empRes.body.id}`);
     expect(getRes.status).toBe(200);
-    expect(getRes.body.restRules?.preferred_shift_id, 'preferred_shift_id não-null').toBe(diurnoId);
+    expect(getRes.body.restRules?.preferred_shift_id, 'preferred_shift_id não-null').not.toBeNull();
     expect(getRes.body.restRules?.preferred_shift_id, 'preferred_shift_id é Diurno').toBe(diurnoId);
   });
 


### PR DESCRIPTION
## Summary

- 12 testes de integração (Vitest + supertest) verificam que o gerador produz semanas com **exatamente 36h ou 42h** conforme o padrão CLT de cada fase do ciclo
- Motoristas DIURNO criados com `preferred_shift_id` explícito em todos os testes (lição do bug #119)
- Cobertura: 3 fases × 2 meses cada, com semanas 36h e 42h validadas por fase

## Critérios de aceite atendidos

| Fase | Padrão | Meses testados | 36h ✓ | 42h ✓ |
|------|--------|----------------|--------|--------|
| 1 | `[36h,42h,42h,36h]` | Mar/2025, Jan/2025 | Mar/2025 cltWi=0 | Mar/2025 cltWi=1, Jan/2025 cltWi=1 |
| 2 | `[42h,42h,36h,42h]` | Jun/2025, Ago/2025 | Jun/2025 cltWi=2, Ago/2025 cltWi=2 | Jun/2025 cltWi=0, Ago/2025 cltWi=0 |
| 3 | `[42h,36h,42h,42h]` | Nov/2025, Mar/2026 | Nov/2025 cltWi=1, Mar/2026 cltWi=1 | Nov/2025 cltWi=0, Mar/2026 cltWi=0 |

## Decisão de design dos cenários

Semanas 42h usam posições [0,2,4,6] incluindo Sáb. Quando o Sáb termina a 19:00, o Dom seguinte tem rest=12h < 24h → Dom bloqueado (fix #98B). As semanas escolhidas evitam esse bloqueio ou aproveitam o comportamento correto do fix #100 (`skippedAny` → 36h uniforme).

## Evidência de execução

### Suite isolada (cltWeekHours.test.js)
```
✓ Fase 1 > Mar/2025 cltWi=0 → 36h exatamente 3×12h               35ms
✓ Fase 1 > Mar/2025 cltWi=1 → 42h com 1 turno de 6h              14ms
✓ Fase 1 > Jan/2025 cltWi=1 → 42h com 1 turno de 6h              10ms
✓ Fase 2 > Jun/2025 cltWi=0 (Jun 1–7) → 42h com 1 turno de 6h   18ms
✓ Fase 2 > Jun/2025 cltWi=2 (Jun 15–21) → 36h exatamente 3×12h  15ms
✓ Fase 2 > Ago/2025 cltWi=0 (Ago 3–9) → 42h com 1 turno de 6h   10ms
✓ Fase 2 > Ago/2025 cltWi=2 (Ago 17–23) → 36h exatamente 3×12h  10ms
✓ Fase 3 > Nov/2025 cltWi=0 (Nov 2–8) → 42h com 1 turno de 6h    9ms
✓ Fase 3 > Nov/2025 cltWi=1 (Nov 9–15) → 36h exatamente 3×12h    8ms
✓ Fase 3 > Mar/2026 cltWi=0 (Mar 1–7) → 42h com 1 turno de 6h    8ms
✓ Fase 3 > Mar/2026 cltWi=1 (Mar 8–14) → 36h exatamente 3×12h    8ms
✓ Lição bug #119 > preferred_shift_id Diurno explícito não-null    4ms

Test Files  1 passed (1)
Tests      12 passed (12)
```

### Suite completa (sem regressões)
```
Test Files  23 passed (23)
Tests      346 passed (346)
```
(334 testes existentes + 12 novos = 346 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)