### PR TITLE
fix(export): exibir número do dia acima do dia da semana no cabeçalho (#125)

### DIFF
--- a/backend/src/services/exportService.js
+++ b/backend/src/services/exportService.js
@@ -55,10 +55,10 @@ export async function exportExcel(month, year) {
     pageSetup: { orientation: 'landscape', fitToPage: true, fitToWidth: 1 },
   });
 
-  // Header row: Employee name + days (dia-da-semana + número, ex: "Seg\n06")
+  // Header row: Employee name + days (número + dia-da-semana, ex: "06\nSeg")
   const headerRow = ['Funcionário', 'Total (h)', ...dates.map((d) => {
     const dow = new Date(d + 'T12:00:00').getDay();
-    return `${DOW_ABBR[dow]}\n${d.slice(8)}`;
+    return `${d.slice(8)}\n${DOW_ABBR[dow]}`;
   })];
   sheet.addRow(headerRow);
 
@@ -171,7 +171,7 @@ export async function exportPdf(month, year) {
 
   const head = [['Funcionário', 'Total (h)', ...dates.map((d) => {
     const dow = new Date(d + 'T12:00:00').getDay();
-    return `${DOW_ABBR[dow]}\n${d.slice(8)}`;
+    return `${d.slice(8)}\n${DOW_ABBR[dow]}`;
   })]];
   const body = [];
   const cellStyles = [];

--- a/backend/src/tests/export.test.js
+++ b/backend/src/tests/export.test.js
@@ -140,20 +140,20 @@ describe('GET /api/export/excel', () => {
     return workbook;
   }
 
-  it('cabeçalho Excel col 3 = "Qua\\n01" (Jan/2025 dia 1 é Quarta-feira)', async () => {
+  it('cabeçalho Excel col 3 = "01\\nQua" (Jan/2025 dia 1 é Quarta-feira)', async () => {
     // Jan 1, 2025 = Quarta-feira (dow=3 → DOW_ABBR[3]='Qua'), número do dia = '01'
     const workbook = await loadExcel(1, 2025);
     const row1 = workbook.worksheets[0].getRow(1);
     expect(row1.getCell(1).value).toBe('Funcionário');
     expect(row1.getCell(2).value).toBe('Total (h)');
-    expect(row1.getCell(3).value).toBe('Qua\n01');
+    expect(row1.getCell(3).value).toBe('01\nQua');
   });
 
-  it('cabeçalho Excel col 33 = "Sex\\n31" (Jan/2025 dia 31 é Sexta-feira)', async () => {
+  it('cabeçalho Excel col 33 = "31\\nSex" (Jan/2025 dia 31 é Sexta-feira)', async () => {
     // Jan 31, 2025 = Sexta-feira (dow=5 → DOW_ABBR[5]='Sex'), número = '31'
     const workbook = await loadExcel(1, 2025);
     // col 1=Funcionário, col 2=Total (h), col 3=dia 1 … col 33=dia 31
-    expect(workbook.worksheets[0].getRow(1).getCell(33).value).toBe('Sex\n31');
+    expect(workbook.worksheets[0].getRow(1).getCell(33).value).toBe('31\nSex');
   });
 
   it('cabeçalho Excel — wrapText habilitado nas colunas de dias', async () => {
@@ -167,10 +167,10 @@ describe('GET /api/export/excel', () => {
     expect(workbook.worksheets[0].getRow(1).height).toBe(30);
   });
 
-  it('cabeçalho Excel — Dom Jun 1, 2025 aparece como "Dom\\n01"', async () => {
+  it('cabeçalho Excel — Dom Jun 1, 2025 aparece como "01\\nDom"', async () => {
     // Jun 1, 2025 = Domingo (dow=0 → DOW_ABBR[0]='Dom')
     const workbook = await loadExcel(6, 2025);
-    expect(workbook.worksheets[0].getRow(1).getCell(3).value).toBe('Dom\n01');
+    expect(workbook.worksheets[0].getRow(1).getCell(3).value).toBe('01\nDom');
   });
 
   it('total de horas dentro do alvo — sem afetar o status da resposta', async () => {


### PR DESCRIPTION
## Contexto do bug

No export (Excel e PDF), o cabeçalho de cada coluna de dia exibia o dia da semana **acima** do número do dia — formato `DOW\nDD` (ex: `"Qua\n01"`). O correto, conforme issue #125, é exibir o **número acima** e o dia da semana abaixo — formato `DD\nDOW` (ex: `"01\nQua"`).

## Mudanças

- `backend/src/services/exportService.js`: invertida a interpolação do template literal em dois pontos — `exportExcel` (linha do `headerRow`) e `exportPdf` (linha do `head`). Antes: `` `${DOW_ABBR[dow]}\n${d.slice(8)}` ``; depois: `` `${d.slice(8)}\n${DOW_ABBR[dow]}` ``.
- `backend/src/tests/export.test.js`: atualizados 3 valores esperados nos testes da feature #122:
  - `'Qua\n01'` → `'01\nQua'`
  - `'Sex\n31'` → `'31\nSex'`
  - `'Dom\n01'` → `'01\nDom'`

## Evidência — output dos testes

```
# Testes do módulo export (28 testes)
Test Files  1 passed (1)
      Tests  28 passed (28)

# Suite completa (sem regressões)
Test Files  23 passed (23)
      Tests  346 passed (346)
```

Todos os 346 testes passam. Nenhuma regressão introduzida.