### PR TITLE
fix(frontend): garantir firstDay=0 (domingo) no CalendarView — fix #135

### DIFF
--- a/frontend/src/components/schedule/CalendarView.jsx
+++ b/frontend/src/components/schedule/CalendarView.jsx
@@ -2,8 +2,6 @@ import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import { useMemo, useRef } from 'react';
-import { format } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
 
 export default function CalendarView({ scheduleData, currentMonth, currentYear, onEntryClick }) {
   const calendarRef = useRef(null);
@@ -40,6 +38,7 @@ export default function CalendarView({ scheduleData, currentMonth, currentYear, 
         initialView="dayGridMonth"
         initialDate={initialDate}
         locale="pt-br"
+        firstDay={0}
         events={events}
         eventClick={(info) => {
           const entry = info.event.extendedProps.entry;


### PR DESCRIPTION
## Problema

O CalendarView usava locale="pt-br" no FullCalendar sem firstDay explícito. A versão instalada não define firstDay no locale pt-BR, portando o valor padrão dependia da implementação interna.

Com firstDay indefinido, semanas podem ser exibidas começando na segunda-feira, fazendo 05/04/2026 (Dom) aparecer na semana de março e a semana de Abril começar em 06/04 (Seg) — horas do turno extra de 6h no domingo não são vistas pelo usuário na semana de Abril.

Removidos também imports não-utilizados (format e ptBR de date-fns/locale).

## Alterações

- CalendarView.jsx: adicionado firstDay={0} explícito; removidos imports mortos

## Evidência

locale pt-BR do FullCalendar instalado (node_modules/@fullcalendar/core/locales/pt-br.js) não define firstDay. Adição explícita garante Dom->Sab independente de atualizações futuras.

Closes #135

Desenvolvedor Pleno via Claude Code