### PR TITLE
infra(db): scripts db:reset e db:seed para ambiente de desenvolvimento — fix #140

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,12 @@ cd frontend && npm run dev    # porta 5173
 # Build de producao
 cd frontend && npm run build
 
-# Testes (ainda nao configurados — ver backlog)
+# Testes
 npm test
+
+# Banco de desenvolvimento (apenas dev — NUNCA em produção)
+cd backend && npm run db:reset   # apaga escala.db e recria schema vazio
+cd backend && npm run db:seed    # popula com 12 funcionários representativos (idempotente)
 ```
 
 ## Architecture

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,9 @@
     "dev": "node --watch --no-warnings=ExperimentalWarning src/index.js",
     "start": "node --no-warnings=ExperimentalWarning src/index.js",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "db:reset": "node --no-warnings=ExperimentalWarning src/db/reset.js",
+    "db:seed": "node --no-warnings=ExperimentalWarning src/db/seed.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/backend/src/db/reset.js
+++ b/backend/src/db/reset.js
@@ -1,0 +1,32 @@
+/**
+ * db:reset — apaga o banco de desenvolvimento e o recria do zero.
+ * Use apenas em ambiente de desenvolvimento. NUNCA em produção.
+ *
+ * Uso: npm run db:reset
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DB_PATH = process.env.DB_PATH || join(__dirname, '..', '..', 'escala.db');
+
+if (DB_PATH === ':memory:') {
+  console.log('DB_PATH=:memory: — nada a apagar.');
+  process.exit(0);
+}
+
+console.log('⚠️  ATENÇÃO: este script apaga permanentemente o banco de desenvolvimento.');
+console.log('   Arquivo:', DB_PATH);
+console.log('');
+
+if (!existsSync(DB_PATH)) {
+  console.log('Banco não encontrado — nada a fazer.');
+  process.exit(0);
+}
+
+rmSync(DB_PATH);
+console.log('Banco apagado com sucesso.');
+console.log('Execute "npm run db:seed" para popular com dados representativos,');
+console.log('ou "npm run dev" para iniciar com banco vazio.');

--- a/backend/src/db/seed.js
+++ b/backend/src/db/seed.js
@@ -1,0 +1,69 @@
+/**
+ * db:seed — popula o banco com um conjunto representativo de funcionários.
+ * Idempotente: não insere duplicatas se o seed já foi executado.
+ *
+ * Uso: npm run db:seed
+ * Recomendado após: npm run db:reset
+ */
+
+import { getDb, runTransaction } from './database.js';
+
+const db = getDb();
+
+const existing = db.prepare('SELECT COUNT(*) as n FROM employees').get();
+if (existing.n > 0) {
+  console.log(`Banco já tem ${existing.n} funcionário(s) — seed ignorado.`);
+  console.log('Para resetar, execute "npm run db:reset" antes do seed.');
+  process.exit(0);
+}
+
+const shifts = db.prepare('SELECT id, name FROM shift_types').all();
+const shiftId = (name) => shifts.find((s) => s.name === name)?.id ?? null;
+
+const SETORES = {
+  amb: 'Transporte Ambulância',
+  hemo: 'Transporte Hemodiálise',
+  adm: 'Transporte Administrativo',
+};
+
+function insertEmployee({ name, cycleMonth, preferredShift, setores, color }) {
+  const res = db.prepare(
+    "INSERT INTO employees (name, cargo, color, cycle_start_month, cycle_start_year) VALUES (?, 'Motorista', ?, ?, 2026)"
+  ).run(name, color, cycleMonth);
+
+  const empId = res.lastInsertRowid;
+
+  for (const setor of setores) {
+    db.prepare('INSERT INTO employee_sectors (employee_id, setor) VALUES (?, ?)').run(empId, setor);
+  }
+
+  db.prepare(
+    'INSERT INTO employee_rest_rules (employee_id, min_rest_hours, preferred_shift_id) VALUES (?, 24, ?)'
+  ).run(empId, preferredShift);
+}
+
+runTransaction(() => {
+  // Ambulância — 4 motoristas: 2 Diurno (ciclos Jan/Fev) + 2 Noturno (ciclos Jan/Mar)
+  insertEmployee({ name: 'Amb Diurno 1',  cycleMonth: 1, preferredShift: shiftId('Diurno'),  setores: [SETORES.amb],  color: '#3B82F6' });
+  insertEmployee({ name: 'Amb Diurno 2',  cycleMonth: 2, preferredShift: shiftId('Diurno'),  setores: [SETORES.amb],  color: '#2563EB' });
+  insertEmployee({ name: 'Amb Noturno 1', cycleMonth: 1, preferredShift: shiftId('Noturno'), setores: [SETORES.amb],  color: '#6366F1' });
+  insertEmployee({ name: 'Amb Noturno 2', cycleMonth: 3, preferredShift: shiftId('Noturno'), setores: [SETORES.amb],  color: '#4F46E5' });
+
+  // Hemodiálise — 4 motoristas: 2 Diurno (ciclos Fev/Mar) + 2 Noturno (ciclos Jan/Fev)
+  insertEmployee({ name: 'Hemo Diurno 1',  cycleMonth: 2, preferredShift: shiftId('Diurno'),  setores: [SETORES.hemo], color: '#10B981' });
+  insertEmployee({ name: 'Hemo Diurno 2',  cycleMonth: 3, preferredShift: shiftId('Diurno'),  setores: [SETORES.hemo], color: '#059669' });
+  insertEmployee({ name: 'Hemo Noturno 1', cycleMonth: 1, preferredShift: shiftId('Noturno'), setores: [SETORES.hemo], color: '#34D399' });
+  insertEmployee({ name: 'Hemo Noturno 2', cycleMonth: 2, preferredShift: shiftId('Noturno'), setores: [SETORES.hemo], color: '#6EE7B7' });
+
+  // Administrativo — 4 motoristas sem turno preferido (null-preferred, ciclos variados)
+  insertEmployee({ name: 'Adm Flex 1', cycleMonth: 1, preferredShift: null, setores: [SETORES.adm], color: '#F59E0B' });
+  insertEmployee({ name: 'Adm Flex 2', cycleMonth: 2, preferredShift: null, setores: [SETORES.adm], color: '#D97706' });
+  insertEmployee({ name: 'Adm Flex 3', cycleMonth: 3, preferredShift: null, setores: [SETORES.adm], color: '#FBBF24' });
+
+  // Polivalente — atende Ambulância e Hemodiálise
+  insertEmployee({ name: 'Polivalente 1', cycleMonth: 1, preferredShift: shiftId('Diurno'), setores: [SETORES.amb, SETORES.hemo], color: '#EC4899' });
+});
+
+const total = db.prepare('SELECT COUNT(*) as n FROM employees').get();
+console.log(`Seed concluído: ${total.n} funcionários inseridos.`);
+console.log('Execute "npm run dev" para iniciar o servidor.');


### PR DESCRIPTION
## Resumo

- `npm run db:reset` — apaga `escala.db` com aviso explícito no console
- `npm run db:seed` — insere 12 funcionários representativos (idempotente)
- `CLAUDE.md` atualizado com os novos comandos

## Funcionários do seed

| Nome | Setor | Turno | Ciclo |
|---|---|---|---|
| Amb Diurno 1 | Ambulância | Diurno | Jan |
| Amb Diurno 2 | Ambulância | Diurno | Fev |
| Amb Noturno 1 | Ambulância | Noturno | Jan |
| Amb Noturno 2 | Ambulância | Noturno | Mar |
| Hemo Diurno 1 | Hemodiálise | Diurno | Fev |
| Hemo Diurno 2 | Hemodiálise | Diurno | Mar |
| Hemo Noturno 1 | Hemodiálise | Noturno | Jan |
| Hemo Noturno 2 | Hemodiálise | Noturno | Fev |
| Adm Flex 1 | Administrativo | null | Jan |
| Adm Flex 2 | Administrativo | null | Fev |
| Adm Flex 3 | Administrativo | null | Mar |
| Polivalente 1 | Amb + Hemo | Diurno | Jan |

## Plano de teste

- [x] `npm run db:seed` com banco cheio → detecta 110 funcionários e ignora (idempotente)
- [x] `npm run db:reset` → apaga banco com aviso
- [x] `npm run db:seed` após reset → insere exatamente 12 funcionários
- [x] `npm run db:seed` executado duas vezes seguidas → segundo run ignorado
- [x] `npm test` continua passando (395 testes)

## Evidência

```
$ npm run db:seed
Banco já tem 110 funcionário(s) — seed ignorado.

$ npm run db:reset
⚠️  ATENÇÃO: este script apaga permanentemente o banco de desenvolvimento.
   Arquivo: /home/darigaz/escalaTati/backend/escala.db
Banco apagado com sucesso.

$ npm run db:seed
Seed concluído: 12 funcionários inseridos.
```

Fecha #140.

**Desenvolvedor Pleno**