### PR TITLE
fix(schedules): filtrar active=1 no GET /api/schedules — fix #141

### DIFF
--- a/backend/src/routes/schedules.js
+++ b/backend/src/routes/schedules.js
@@ -53,7 +53,7 @@ router.get('/', (req, res) => {
               e.work_schedule as employee_work_schedule,
               st.name as shift_name, st.color as shift_color, st.start_time, st.end_time, st.duration_hours
        FROM schedule_entries se
-       JOIN employees e ON se.employee_id = e.id
+       JOIN employees e ON se.employee_id = e.id AND e.active = 1
        LEFT JOIN shift_types st ON se.shift_type_id = st.id
        WHERE se.date >= ? AND se.date <= ?
        ORDER BY se.date, e.name`

--- a/backend/src/tests/inactiveEmployeeSchedule.test.js
+++ b/backend/src/tests/inactiveEmployeeSchedule.test.js
@@ -1,0 +1,134 @@
+/**
+ * test(schedules): funcionários inativos (active=0) não aparecem no GET /api/schedules — bug #141
+ *
+ * Critérios de aceite (issue #141):
+ *   - GET /api/schedules não retorna entries de funcionários com active=0
+ *   - generateSchedule não processa funcionários com active=0 (já era correto — regressão)
+ *   - Fluxo: gerar → inativar → regenerar → entries do inativo não reaparecem
+ *   - Entries históricas do inativo permanecem no banco (soft delete — dados preservados)
+ *
+ * Tester Senior
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../app.js';
+import { freshDb, createEmployee } from './helpers.js';
+
+const MONTH = { month: 4, year: 2026 };
+
+beforeEach(() => freshDb());
+
+// ── Suíte 1: GET /api/schedules filtra active=0 ──────────────────────────────
+
+describe('GET /api/schedules — funcionários inativos excluídos da resposta', () => {
+  it('entries de funcionário inativado não aparecem no GET /api/schedules', async () => {
+    const db = freshDb();
+    const ativo = createEmployee(db, { name: 'Ativo' });
+    const inativo = createEmployee(db, { name: 'Inativo' });
+
+    // Gerar escala com ambos ativos
+    const gen = await request(app).post('/api/schedules/generate').send(MONTH);
+    expect(gen.status).toBe(200);
+
+    // Inativar funcionário
+    db.prepare('UPDATE employees SET active = 0 WHERE id = ?').run(inativo.id);
+
+    // GET /api/schedules não deve retornar entries do inativo
+    const res = await request(app).get('/api/schedules?month=4&year=2026');
+    expect(res.status).toBe(200);
+
+    const ids = [...new Set(res.body.entries.map((e) => e.employee_id))];
+    expect(ids).toContain(ativo.id);
+    expect(ids).not.toContain(inativo.id);
+  });
+
+  it('totals não incluem funcionário inativado', async () => {
+    const db = freshDb();
+    const ativo = createEmployee(db, { name: 'Ativo' });
+    const inativo = createEmployee(db, { name: 'Inativo' });
+
+    await request(app).post('/api/schedules/generate').send(MONTH);
+    db.prepare('UPDATE employees SET active = 0 WHERE id = ?').run(inativo.id);
+
+    const res = await request(app).get('/api/schedules?month=4&year=2026');
+    expect(res.status).toBe(200);
+
+    const totalIds = res.body.totals.map((t) => t.employee_id);
+    expect(totalIds).toContain(ativo.id);
+    expect(totalIds).not.toContain(inativo.id);
+  });
+
+  it('entries do inativo permanecem no banco (soft delete — dados preservados)', async () => {
+    const db = freshDb();
+    const inativo = createEmployee(db, { name: 'Inativo' });
+
+    await request(app).post('/api/schedules/generate').send(MONTH);
+
+    // Confirmar que entries existem antes de inativar
+    const antes = db
+      .prepare('SELECT COUNT(*) as n FROM schedule_entries WHERE employee_id = ?')
+      .get(inativo.id);
+    expect(antes.n).toBeGreaterThan(0);
+
+    db.prepare('UPDATE employees SET active = 0 WHERE id = ?').run(inativo.id);
+
+    // Entries ainda existem no banco após inativação
+    const depois = db
+      .prepare('SELECT COUNT(*) as n FROM schedule_entries WHERE employee_id = ?')
+      .get(inativo.id);
+    expect(depois.n).toBe(antes.n);
+  });
+});
+
+// ── Suíte 2: regeneração não recria entries para inativos ────────────────────
+
+describe('generateSchedule — funcionário inativado não reaparece após regeneração', () => {
+  it('regenerar o mês não cria novas entries para funcionário inativo', async () => {
+    const db = freshDb();
+    const ativo = createEmployee(db, { name: 'Ativo' });
+    const inativo = createEmployee(db, { name: 'Inativo' });
+
+    // Primeira geração com ambos
+    await request(app).post('/api/schedules/generate').send(MONTH);
+
+    const entriesAntes = db
+      .prepare('SELECT COUNT(*) as n FROM schedule_entries WHERE employee_id = ?')
+      .get(inativo.id).n;
+
+    // Inativar e regenerar
+    db.prepare('UPDATE employees SET active = 0 WHERE id = ?').run(inativo.id);
+    const regen = await request(app)
+      .post('/api/schedules/generate')
+      .send({ ...MONTH, overwriteLocked: true });
+    expect(regen.status).toBe(200);
+
+    // Entries do inativo não devem ter aumentado
+    const entriesDepois = db
+      .prepare('SELECT COUNT(*) as n FROM schedule_entries WHERE employee_id = ?')
+      .get(inativo.id).n;
+    expect(entriesDepois).toBe(entriesAntes);
+
+    // GET não retorna entries do inativo
+    const res = await request(app).get('/api/schedules?month=4&year=2026');
+    const ids = [...new Set(res.body.entries.map((e) => e.employee_id))];
+    expect(ids).toContain(ativo.id);
+    expect(ids).not.toContain(inativo.id);
+  });
+
+  it('funcionário nunca ativo não aparece em GET /api/schedules', async () => {
+    const db = freshDb();
+    const ativo = createEmployee(db, { name: 'Ativo' });
+    const nunca = createEmployee(db, { name: 'Nunca Ativo' });
+
+    // Inativar antes da primeira geração
+    db.prepare('UPDATE employees SET active = 0 WHERE id = ?').run(nunca.id);
+
+    await request(app).post('/api/schedules/generate').send(MONTH);
+
+    const res = await request(app).get('/api/schedules?month=4&year=2026');
+    const ids = [...new Set(res.body.entries.map((e) => e.employee_id))];
+    expect(ids).toContain(ativo.id);
+    expect(ids).not.toContain(nunca.id);
+  });
+});


### PR DESCRIPTION
## Resumo

- `GET /api/schedules`: adicionado `AND e.active = 1` no JOIN com `employees`
- Funcionários soft-deletados (`active=0`) não aparecem mais no CalendarView nem nos totais
- Entries históricas preservadas no banco (soft delete — sem perda de dados)
- `generateSchedule` já filtrava `active=1` corretamente — confirmado por regressão

## Mudança

```sql
-- Antes
JOIN employees e ON se.employee_id = e.id

-- Depois
JOIN employees e ON se.employee_id = e.id AND e.active = 1
```

## Plano de teste

5 novos testes em `inactiveEmployeeSchedule.test.js`:

- [x] GET não retorna entries de funcionário inativado
- [x] totals não incluem funcionário inativado
- [x] entries permanecem no banco após inativação (soft delete preserva histórico)
- [x] regenerar mês não recria entries para inativo
- [x] funcionário inativado antes da primeira geração não aparece

## Evidência

```
Test Files  26 passed (26)
      Tests 400 passed (400)
```

Fecha #141.

**Desenvolvedor Pleno**