### PR TITLE
infra(deploy): substituir Railway por Render + Neon (zero custo)

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,8 +1,0 @@
-[build]
-builder = "NIXPACKS"
-buildCommand = "npm ci && npm run build --workspace=frontend"
-
-[deploy]
-startCommand = "npm start --workspace=backend"
-restartPolicyType = "ON_FAILURE"
-restartPolicyMaxRetries = 3

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: escalatati
+    env: node
+    plan: free
+    buildCommand: npm ci && npm run build --workspace=frontend
+    startCommand: npm start --workspace=backend
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_URL
+        sync: false


### PR DESCRIPTION
## Summary

Substitui Railway por **Render + Neon** — stack zero custo permanente.

| Serviço | Plano | Custo |
|---|---|---|
| Render (backend+frontend) | Free — 750h/mês | $0 |
| Neon (PostgreSQL) | Free — 0.5 GB | $0 |

### Mudanças

- **Remove** `railway.toml`
- **Adiciona** `render.yaml`: mesmos build/start commands, `NODE_ENV=production`, `DATABASE_URL` via sync:false (configurada manualmente com a string do Neon)

### Setup no Render + Neon

**1. Neon** (neon.tech):
- Criar projeto → copiar `DATABASE_URL` (formato `postgresql://user:pass@host/db?sslmode=require`)

**2. Render** (render.com):
- New → Blueprint → conectar repo `D4rigaz/escalaTati` (detecta `render.yaml`)
- Em Environment Variables, adicionar `DATABASE_URL` copiada do Neon

### Limitação conhecida

Render free hiberna após 15 min de inatividade — primeiro request após hibernação leva ~30s (cold start). Aceitável para uso interno.

## Test plan

- [ ] CI passa (sem alteração de lógica)
- [ ] `render.yaml` válido (Render detecta e cria o serviço)
- [ ] `GET /api/health` retorna `{ status: "ok" }` após deploy
- [ ] Frontend carrega na URL do Render

🤖 Generated with [Claude Code](https://claude.com/claude-code)