### PR TITLE
fix(render): --include=dev no buildCommand (vite not found)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: escalatati
     env: node
     plan: free
-    buildCommand: npm ci && npm run build --workspace=frontend
+    buildCommand: npm ci --include=dev && npm run build --workspace=frontend
     startCommand: npm start --workspace=backend
     envVars:
       - key: NODE_ENV


### PR DESCRIPTION
## Problema

`NODE_ENV=production` (definido no `render.yaml`) faz o `npm ci` pular `devDependencies` durante o build. O `vite` é `devDependency` do workspace frontend — logo não era instalado e o build falhava com:

```
sh: 1: vite: not found
npm error code 127
```

## Fix

`--include=dev` força a instalação das devDependencies independente do `NODE_ENV`.

```diff
-buildCommand: npm ci && npm run build --workspace=frontend
+buildCommand: npm ci --include=dev && npm run build --workspace=frontend
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)